### PR TITLE
rychkov.mihail/F0

### DIFF
--- a/rychkov.mihail/F0/boost_link_deps.cpp
+++ b/rychkov.mihail/F0/boost_link_deps.cpp
@@ -1,0 +1,1 @@
+#include <boost/json/src.hpp>

--- a/rychkov.mihail/F0/compare.cpp
+++ b/rychkov.mihail/F0/compare.cpp
@@ -1,0 +1,34 @@
+#include "compare.hpp"
+
+#include "content.hpp"
+
+bool rychkov::NameCompare::operator()(const std::string& lhs, const std::string& rhs) const
+{
+  return lhs < rhs;
+}
+
+bool rychkov::NameCompare::operator()(const operator_value& lhs, const operator_value& rhs) const
+{
+  return operator()(lhs[0], rhs[0]);
+}
+bool rychkov::NameCompare::operator()(const operator_value& lhs, const std::string& rhs) const
+{
+  return operator()(lhs[0], rhs);
+}
+bool rychkov::NameCompare::operator()(const std::string& lhs, const operator_value& rhs) const
+{
+  return operator()(lhs, rhs[0]);
+}
+
+bool rychkov::NameCompare::operator()(const Operator& lhs, const Operator& rhs) const
+{
+  return lhs.token < rhs.token;
+}
+bool rychkov::NameCompare::operator()(const Operator& lhs, const std::string& rhs) const
+{
+  return lhs.token < rhs;
+}
+bool rychkov::NameCompare::operator()(const std::string& lhs, const Operator& rhs) const
+{
+  return lhs < rhs.token;
+}

--- a/rychkov.mihail/F0/compare.hpp
+++ b/rychkov.mihail/F0/compare.hpp
@@ -1,0 +1,79 @@
+#ifndef COMPARE_HPP
+#define COMPARE_HPP
+
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace rychkov
+{
+  struct Operator;
+  namespace entities
+  {
+    template< class T >
+    const std::string& get_name(const T& entity);
+    const std::string& get_name(const std::string& identity);
+  }
+  struct NameCompare
+  {
+    using is_transparent = void;
+    using operator_value = std::vector< Operator >;
+    bool operator()(const std::string& lhs, const std::string& rhs) const;
+
+    bool operator()(const operator_value& lhs, const operator_value& rhs) const;
+    bool operator()(const operator_value& lhs, const std::string& rhs) const;
+    bool operator()(const std::string& lhs, const operator_value& rhs) const;
+
+    bool operator()(const Operator& lhs, const Operator& rhs) const;
+    bool operator()(const Operator& lhs, const std::string& rhs) const;
+    bool operator()(const std::string& lhs, const Operator& rhs) const;
+
+    template< class T >
+    bool operator()(const std::pair< T, size_t >& lhs, const std::pair< T, size_t >& rhs) const;
+    template< class T >
+    bool operator()(const std::pair< T, size_t >& lhs, const std::string& rhs) const;
+    template< class T >
+    bool operator()(const std::string& lhs, const std::pair< T, size_t >& rhs) const;
+
+    template< class T >
+    bool operator()(const T& lhs, const T& rhs) const;
+    template< class T >
+    bool operator()(const T& lhs, const std::string& rhs) const;
+    template< class T >
+    bool operator()(const std::string& lhs, const T& rhs) const;
+  };
+}
+
+template< class T >
+bool rychkov::NameCompare::operator()(const std::pair< T, size_t >& lhs, const std::pair< T, size_t >& rhs) const
+{
+  return operator()(lhs.first, rhs.first) || (!operator()(rhs.first, lhs.first) && (lhs.second > rhs.second));
+}
+template< class T >
+bool rychkov::NameCompare::operator()(const std::pair< T, size_t >& lhs, const std::string& rhs) const
+{
+  return operator()(lhs.first, rhs);
+}
+template< class T >
+bool rychkov::NameCompare::operator()(const std::string& lhs, const std::pair< T, size_t >& rhs) const
+{
+  return operator()(lhs, rhs.first);
+}
+
+template< class T >
+bool rychkov::NameCompare::operator()(const T& lhs, const T& rhs) const
+{
+  return entities::get_name(lhs) < entities::get_name(rhs);
+}
+template< class T >
+bool rychkov::NameCompare::operator()(const T& lhs, const std::string& rhs) const
+{
+  return entities::get_name(lhs) < rhs;
+}
+template< class T >
+bool rychkov::NameCompare::operator()(const std::string& lhs, const T& rhs) const
+{
+  return lhs < entities::get_name(rhs);
+}
+
+#endif

--- a/rychkov.mihail/F0/content.cpp
+++ b/rychkov.mihail/F0/content.cpp
@@ -1,0 +1,272 @@
+#include "content.hpp"
+
+#include <utility>
+
+bool rychkov::typing::Type::empty() const noexcept
+{
+  return (category == COMBINATION) && !is_const && !is_volatile && !is_signed && !is_unsigned;
+}
+bool rychkov::typing::Type::ready() const noexcept
+{
+  return (category != COMBINATION) || (base != nullptr);
+}
+rychkov::entities::Expression::Expression():
+  operation{nullptr},
+  result_type{}
+{}
+rychkov::entities::Expression::Expression(Variable var):
+  operation{nullptr},
+  result_type{var.type},
+  operands{std::move(var)}
+{}
+rychkov::entities::Expression::Expression(Declaration decl):
+  operation{nullptr},
+  result_type{},
+  operands{std::move(decl)}
+{}
+rychkov::entities::Expression::Expression(Literal lit):
+  operation{nullptr},
+  result_type{lit.result_type},
+  operands{std::move(lit)}
+{}
+rychkov::entities::Expression::Expression(CastOperation cast):
+  operation{nullptr},
+  result_type{cast.to},
+  operands{std::move(cast)}
+{}
+rychkov::entities::Expression::Expression(Body body):
+  operation{nullptr},
+  result_type{},
+  operands{std::move(body)}
+{}
+rychkov::entities::Expression::Expression(const Operator* op, std::vector< operand > opers):
+  operation{op},
+  result_type{},
+  operands(std::move(opers))
+{}
+rychkov::entities::Body::Body():
+  data{{}}
+{}
+
+const std::string& rychkov::entities::get_name(const std::string& identity)
+{
+  return identity;
+}
+
+bool rychkov::entities::Expression::empty() const noexcept
+{
+  return (operation == nullptr) && operands.empty();
+}
+bool rychkov::entities::Expression::full() const noexcept
+{
+  if (operation == nullptr)
+  {
+    return !operands.empty();
+  }
+  if (operation->type == -1)
+  {
+    return false;
+  }
+  return static_cast< std::ptrdiff_t >(operands.size()) >= operation->type;
+}
+bool rychkov::entities::is_body(const Expression& expr)
+{
+  return (expr.operation == nullptr) && !expr.operands.empty()
+      && boost::variant2::holds_alternative< Body >(expr.operands[0]);
+}
+bool rychkov::entities::is_decl(const Expression& expr)
+{
+  return (expr.operation == nullptr) && !expr.operands.empty()
+      && boost::variant2::holds_alternative< Declaration >(expr.operands[0]);
+}
+bool rychkov::entities::is_operator(const Expression& expr)
+{
+  return expr.operation != nullptr;
+}
+bool rychkov::entities::is_bridge(const Expression& expr)
+{
+  return expr.operation == nullptr;
+}
+
+void rychkov::entities::remove_bridge(Expression& expr)
+{
+  if (!is_bridge(expr) || (expr.operands.size() != 1))
+  {
+    return;
+  }
+  if (!boost::variant2::holds_alternative< DynMemWrapper< Expression > >(expr.operands[0]))
+  {
+    return;
+  }
+  Expression temp = std::move(*boost::variant2::get< DynMemWrapper< Expression > >(expr.operands[0]));
+  expr = std::move(temp);
+}
+
+const rychkov::typing::Type* rychkov::entities::get_type(const Expression::operand& operand)
+{
+  if (boost::variant2::holds_alternative< DynMemWrapper< Expression > >(operand))
+  {
+    return &boost::variant2::get< DynMemWrapper< Expression > >(operand)->result_type;
+  }
+  else if (boost::variant2::holds_alternative< Variable >(operand))
+  {
+    return &boost::variant2::get< Variable >(operand).type;
+  }
+  else if (boost::variant2::holds_alternative< Literal >(operand))
+  {
+    return &boost::variant2::get< Literal >(operand).result_type;
+  }
+  else if (boost::variant2::holds_alternative< CastOperation >(operand))
+  {
+    return &boost::variant2::get< Variable >(operand).type;
+  }
+  return nullptr;
+}
+bool rychkov::entities::is_lvalue(const Expression::operand& operand)
+{
+  if (boost::variant2::holds_alternative< DynMemWrapper< Expression > >(operand))
+  {
+    return is_lvalue(&*boost::variant2::get< DynMemWrapper< Expression > >(operand));
+  }
+  return boost::variant2::holds_alternative< entities::Variable >(operand);
+}
+bool rychkov::entities::is_lvalue(const Expression* expr)
+{
+  if ((expr->operation == nullptr) || (expr->operation->token == ","))
+  {
+    return !expr->operands.empty() && is_lvalue(expr->operands.back());
+  }
+  return expr->operation->produce_lvalue;
+}
+
+bool rychkov::typing::exact_cv(const Type& dest, const Type& src)
+{
+  return (dest.is_const == src.is_const) && (dest.is_volatile == src.is_volatile) && (check_cast(dest, src) == EXACT);
+}
+rychkov::typing::MatchType rychkov::typing::check_cast(const Type& dest, const Type& src)
+{
+  if (dest.category != src.category)
+  {
+    if (is_integer(&dest) && (is_iterable(&src)))
+    {
+      return IMPLICIT;
+    }
+    if (is_pointer(&dest) && is_array(&src))
+    {
+      return check_cast(*dest.base, *src.base) == EXACT ? IMPLICIT : NO_CAST;
+    }
+    if (is_pointer(&dest) && is_function(&src))
+    {
+      return exact_cv(*dest.base, src) ? IMPLICIT : NO_CAST;
+    }
+    if (is_integer(&dest) && is_enum(&src))
+    {
+      return IMPLICIT;
+    }
+    return NO_CAST;
+  }
+
+  switch (dest.category)
+  {
+  case STRUCT:
+  case ENUM:
+    return dest.name == src.name ? EXACT : NO_CAST;
+  case BASIC:
+    return EXACT;
+  case FUNCTION:
+    return exact_cv(*dest.base, *src.base) && std::equal(dest.function_parameters.begin(),
+          dest.function_parameters.end(), src.function_parameters.begin(), src.function_parameters.end(),
+          exact_cv) ? EXACT : NO_CAST;
+  case POINTER:
+    if ((!dest.base->is_const && src.base->is_const) || (!dest.base->is_volatile && src.base->is_volatile))
+    {
+      return NO_CAST;
+    }
+    return check_cast(*dest.base, *src.base) == EXACT ? EXACT : NO_CAST;
+  case ARRAY:
+    if (dest.array_has_length && (dest.array_length != src.array_length))
+    {
+      return NO_CAST;
+    }
+    return check_cast(*dest.base, *src.base) == EXACT ? EXACT : NO_CAST;
+  default:
+    return NO_CAST;
+  }
+}
+rychkov::typing::MatchType rychkov::typing::check_overload(const Type& function, const std::vector< Type >& args)
+{
+  if (function.function_parameters.size() != args.size())
+  {
+    return NO_CAST;
+  }
+  MatchType result = EXACT;
+  for (size_t i = 0; i < args.size(); i++)
+  {
+    switch (check_cast(function.function_parameters[i], args[i]))
+    {
+    case EXACT:
+      break;
+    case IMPLICIT:
+      result = IMPLICIT;
+      break;
+    case NO_CAST:
+      return NO_CAST;
+    }
+  }
+  return result;
+}
+
+const rychkov::typing::Type* rychkov::typing::largest_integer(const Type& lhs, const Type& rhs)
+{
+  if (!is_integer(&lhs) || !is_integer(&rhs))
+  {
+    return nullptr;
+  }
+  return &lhs;
+}
+const rychkov::typing::Type* rychkov::typing::common_type(const Type& lhs, const Type& rhs)
+{
+  if ((!is_basic(&lhs) && !is_pointer(&lhs) && !is_array(&lhs)) || !is_basic(&rhs))
+  {
+    return nullptr;
+  }
+  return &lhs;
+}
+bool rychkov::typing::pointer_comparable(const Type& lhs, const Type& rhs)
+{
+  return (is_pointer(&lhs) || is_array(&lhs)) && (is_pointer(&rhs) || is_array(&rhs))
+      && (check_cast(lhs, rhs) == EXACT);
+}
+
+bool rychkov::typing::is_basic(const Type* type)
+{
+  return (type != nullptr) && (type->category == BASIC);
+}
+bool rychkov::typing::is_enum(const Type* type)
+{
+  return (type != nullptr) && (type->category == ENUM);
+}
+bool rychkov::typing::is_function(const Type* type)
+{
+  return (type != nullptr) && (type->category == FUNCTION);
+}
+bool rychkov::typing::is_pointer(const Type* type)
+{
+  return (type != nullptr) && (type->category == POINTER);
+}
+bool rychkov::typing::is_array(const Type* type)
+{
+  return (type != nullptr) && (type->category == ARRAY);
+}
+bool rychkov::typing::is_callable(const Type* type)
+{
+  return is_function(type) || (is_pointer(type) && is_function(&*type->base));
+}
+bool rychkov::typing::is_iterable(const Type* type)
+{
+  return is_pointer(type) || is_array(type);
+}
+bool rychkov::typing::is_integer(const Type* type)
+{
+  return is_basic(type) && ((type->name == "int") || (type->name == "char"));
+}

--- a/rychkov.mihail/F0/content.cpp
+++ b/rychkov.mihail/F0/content.cpp
@@ -72,12 +72,12 @@ bool rychkov::entities::Expression::full() const noexcept
 bool rychkov::entities::is_body(const Expression& expr)
 {
   return (expr.operation == nullptr) && !expr.operands.empty()
-      && boost::variant2::holds_alternative< Body >(expr.operands[0]);
+      && holds_alternative< Body >(expr.operands[0]);
 }
 bool rychkov::entities::is_decl(const Expression& expr)
 {
   return (expr.operation == nullptr) && !expr.operands.empty()
-      && boost::variant2::holds_alternative< Declaration >(expr.operands[0]);
+      && holds_alternative< Declaration >(expr.operands[0]);
 }
 bool rychkov::entities::is_operator(const Expression& expr)
 {
@@ -94,41 +94,41 @@ void rychkov::entities::remove_bridge(Expression& expr)
   {
     return;
   }
-  if (!boost::variant2::holds_alternative< DynMemWrapper< Expression > >(expr.operands[0]))
+  if (!holds_alternative< DynMemWrapper< Expression > >(expr.operands[0]))
   {
     return;
   }
-  Expression temp = std::move(*boost::variant2::get< DynMemWrapper< Expression > >(expr.operands[0]));
+  Expression temp = std::move(*get< DynMemWrapper< Expression > >(expr.operands[0]));
   expr = std::move(temp);
 }
 
 const rychkov::typing::Type* rychkov::entities::get_type(const Expression::operand& operand)
 {
-  if (boost::variant2::holds_alternative< DynMemWrapper< Expression > >(operand))
+  if (holds_alternative< DynMemWrapper< Expression > >(operand))
   {
-    return &boost::variant2::get< DynMemWrapper< Expression > >(operand)->result_type;
+    return &get< DynMemWrapper< Expression > >(operand)->result_type;
   }
-  else if (boost::variant2::holds_alternative< Variable >(operand))
+  else if (holds_alternative< Variable >(operand))
   {
-    return &boost::variant2::get< Variable >(operand).type;
+    return &get< Variable >(operand).type;
   }
-  else if (boost::variant2::holds_alternative< Literal >(operand))
+  else if (holds_alternative< Literal >(operand))
   {
-    return &boost::variant2::get< Literal >(operand).result_type;
+    return &get< Literal >(operand).result_type;
   }
-  else if (boost::variant2::holds_alternative< CastOperation >(operand))
+  else if (holds_alternative< CastOperation >(operand))
   {
-    return &boost::variant2::get< Variable >(operand).type;
+    return &get< Variable >(operand).type;
   }
   return nullptr;
 }
 bool rychkov::entities::is_lvalue(const Expression::operand& operand)
 {
-  if (boost::variant2::holds_alternative< DynMemWrapper< Expression > >(operand))
+  if (holds_alternative< DynMemWrapper< Expression > >(operand))
   {
-    return is_lvalue(&*boost::variant2::get< DynMemWrapper< Expression > >(operand));
+    return is_lvalue(&*get< DynMemWrapper< Expression > >(operand));
   }
-  return boost::variant2::holds_alternative< entities::Variable >(operand);
+  return holds_alternative< entities::Variable >(operand);
 }
 bool rychkov::entities::is_lvalue(const Expression* expr)
 {

--- a/rychkov.mihail/F0/content.hpp
+++ b/rychkov.mihail/F0/content.hpp
@@ -1,0 +1,290 @@
+#ifndef CONTENT_HPP
+#define CONTENT_HPP
+
+#include <cstddef>
+#include <memory>
+#include <string>
+#include <vector>
+#include <set>
+#include <map>
+#include <boost/variant2.hpp>
+#include <utility>
+#include "compare.hpp"
+
+namespace rychkov
+{
+  template< class T >
+  struct DynMemWrapper: std::unique_ptr< T >
+  {
+    using value_type = T;
+    DynMemWrapper():
+      std::unique_ptr< T >(new T)
+    {}
+    DynMemWrapper(const DynMemWrapper& rhs):
+      std::unique_ptr< T >(rhs != nullptr ? new T{*rhs} : nullptr)
+    {}
+    DynMemWrapper(DynMemWrapper&&) = default;
+    DynMemWrapper(std::nullptr_t):
+      std::unique_ptr< T >(nullptr)
+    {}
+    DynMemWrapper(T* ptr):
+      std::unique_ptr< T >(ptr)
+    {}
+    template< class... Args >
+    DynMemWrapper(Args&&... args):
+      std::unique_ptr< T >(new T{std::forward< Args >(args)...})
+    {}
+    DynMemWrapper& operator=(const DynMemWrapper& rhs)
+    {
+      if (rhs != nullptr)
+      {
+        static_cast< std::unique_ptr< T >& >(*this).reset(new T{*rhs});
+      }
+      return *this;
+    }
+    DynMemWrapper& operator=(DynMemWrapper&&) = default;
+    template< class U = T >
+    DynMemWrapper& operator=(U&& rhs)
+    {
+      static_cast< std::unique_ptr< T >& >(*this).reset(new T{std::forward< U >(rhs)});
+      return *this;
+    }
+    DynMemWrapper& operator=(std::nullptr_t)
+    {
+      static_cast< std::unique_ptr< T >& >(*this) = nullptr;
+      return *this;
+    }
+    DynMemWrapper& operator=(T* ptr)
+    {
+      static_cast< std::unique_ptr< T >& >(*this).reset(ptr);
+      return *this;
+    }
+  };
+
+  struct Macro
+  {
+    std::string name;
+    std::string body;
+    bool func_style = false;
+    std::vector< std::string > parameters;
+  };
+  struct Operator
+  {
+    enum Type
+    {
+      UNARY = 1,
+      BINARY = 2,
+      TERNARY = 3,
+      MULTIPLE = -1
+    };
+    enum Category
+    {
+      ARITHMETIC,
+      INCREMENT,
+      MODULUS,
+      LOGIC,
+      COMPARE,
+      BIT,
+      DEREFERENCE,
+      ADDRESSOF,
+      FIELD_ACCESS,
+      SPECIAL,
+      ASSIGN
+    };
+
+    Type type;
+    Category category;
+    std::string token;
+    bool require_lvalue = false;
+    bool right_align = false;
+    bool produce_lvalue = false;
+    int priority = 0;
+  };
+  namespace typing
+  {
+    enum LengthCategory
+    {
+      NO_LENGTH,
+      SHORT,
+      LONG,
+      LONG_LONG
+    };
+    enum Category
+    {
+      STRUCT,
+      ENUM,
+      BASIC,
+      POINTER,
+      ARRAY,
+      FUNCTION,
+      COMBINATION
+    };
+    enum MatchType
+    {
+      EXACT,
+      IMPLICIT,
+      NO_CAST
+    };
+    struct Type
+    {
+      std::string name;
+      Category category = COMBINATION;
+      DynMemWrapper< Type > base = nullptr;
+      bool is_const = false;
+      bool is_volatile = false;
+      bool is_signed = false;
+      bool is_unsigned = false;
+      LengthCategory length_category = NO_LENGTH;
+      bool array_has_length = false;
+      size_t array_length = 0;
+      std::vector< Type > function_parameters;
+
+      bool empty() const noexcept;
+      bool ready() const noexcept;
+    };
+    bool is_basic(const Type* type);
+    bool is_enum(const Type* type);
+    bool is_function(const Type* type);
+    bool is_pointer(const Type* type);
+    bool is_array(const Type* type);
+    bool is_callable(const Type* type);
+    bool is_iterable(const Type* type);
+    bool is_integer(const Type* type);
+
+    bool exact_cv(const Type& dest, const Type& src);
+    MatchType check_cast(const Type& dest, const Type& src);
+    MatchType check_overload(const Type& function, const std::vector< Type >& args);
+    const typing::Type* largest_integer(const Type& lhs, const Type& rhs);
+    const typing::Type* common_type(const Type& lhs, const Type& rhs);
+    bool pointer_comparable(const Type& lhs, const Type& rhs);
+  }
+  namespace entities
+  {
+    enum ScopeType
+    {
+      EXTERN,
+      STATIC,
+      UNSPECIFIED
+    };
+    struct Expression;
+    struct Body
+    {
+      Body();
+      std::vector< Expression > data;
+    };
+    struct Variable
+    {
+      typing::Type type;
+      std::string name;
+    };
+    struct Function
+    {
+      typing::Type type;
+      std::string name;
+      std::vector< std::string > parameters;
+    };
+    struct Statement
+    {
+      enum Type
+      {
+        IF,
+        ELSE,
+        FOR,
+        WHILE,
+        DO,
+        RETURN,
+        DO_WHILE,
+        TYPE_LAST
+      };
+      Type type;
+      std::vector< Expression > conditions;
+    };
+    struct Struct
+    {
+      std::string name;
+      std::set< Variable, NameCompare > fields;
+    };
+    struct Enum
+    {
+      std::string name;
+      std::map< std::string, int, NameCompare > fields;
+    };
+    struct Union
+    {
+      std::string name;
+      std::set< Variable, NameCompare > fields;
+    };
+    struct Alias
+    {
+      typing::Type type;
+      std::string name;
+    };
+    struct Declaration
+    {
+      using declared = boost::variant2::variant< Variable, Struct, Enum, Union, Alias, Function, Statement >;
+      declared data;
+      DynMemWrapper< Expression > value = nullptr;
+      ScopeType scope = UNSPECIFIED;
+    };
+    struct CastOperation
+    {
+      typing::Type to;
+      bool is_explicit = false;
+      DynMemWrapper< Expression > expr;
+    };
+    struct Literal
+    {
+      enum Type
+      {
+        Char,
+        String,
+        Number
+      };
+
+      std::string literal;
+      std::string suffix;
+      Type type;
+      typing::Type result_type;
+    };
+    struct Expression
+    {
+      using operand = boost::variant2::variant< DynMemWrapper< Expression >, Variable,
+            Declaration, Literal, CastOperation, Body >;
+
+      const Operator* operation;
+      typing::Type result_type;
+      std::vector< operand > operands;
+
+      Expression();
+      Expression(Variable var);
+      Expression(Declaration decl);
+      Expression(Literal lit);
+      Expression(CastOperation cast);
+      Expression(Body body);
+      Expression(const Operator* op, std::vector< operand > opers);
+
+      bool empty() const noexcept;
+      bool full() const noexcept;
+    };
+
+    bool is_body(const Expression& expr);
+    bool is_decl(const Expression& expr);
+    bool is_operator(const Expression& expr);
+    bool is_bridge(const Expression& expr);
+
+    void remove_bridge(Expression& expr);
+    const typing::Type* get_type(const Expression::operand& expr);
+    bool is_lvalue(const Expression::operand& operand);
+    bool is_lvalue(const Expression* expr);
+
+    template< class T >
+    const std::string& get_name(const T& entity)
+    {
+      return entity.name;
+    }
+    const std::string& get_name(const std::string& identity);
+  }
+}
+
+#endif
+

--- a/rychkov.mihail/F0/content.hpp
+++ b/rychkov.mihail/F0/content.hpp
@@ -3,12 +3,12 @@
 
 #include <cstddef>
 #include <memory>
+#include <utility>
 #include <string>
 #include <vector>
-#include <set>
-#include <map>
-#include <boost/variant2.hpp>
-#include <utility>
+#include <set.hpp>
+#include <map.hpp>
+#include <variant.hpp>
 #include "compare.hpp"
 
 namespace rychkov
@@ -202,17 +202,17 @@ namespace rychkov
     struct Struct
     {
       std::string name;
-      std::set< Variable, NameCompare > fields;
+      Set< Variable, NameCompare > fields;
     };
     struct Enum
     {
       std::string name;
-      std::map< std::string, int, NameCompare > fields;
+      Map< std::string, int, NameCompare > fields;
     };
     struct Union
     {
       std::string name;
-      std::set< Variable, NameCompare > fields;
+      Set< Variable, NameCompare > fields;
     };
     struct Alias
     {
@@ -221,7 +221,7 @@ namespace rychkov
     };
     struct Declaration
     {
-      using declared = boost::variant2::variant< Variable, Struct, Enum, Union, Alias, Function, Statement >;
+      using declared = Variant< Variable, Struct, Enum, Union, Alias, Function, Statement >;
       declared data;
       DynMemWrapper< Expression > value = nullptr;
       ScopeType scope = UNSPECIFIED;
@@ -248,7 +248,7 @@ namespace rychkov
     };
     struct Expression
     {
-      using operand = boost::variant2::variant< DynMemWrapper< Expression >, Variable,
+      using operand = Variant< DynMemWrapper< Expression >, Variable,
             Declaration, Literal, CastOperation, Body >;
 
       const Operator* operation;

--- a/rychkov.mihail/F0/cparser.cpp
+++ b/rychkov.mihail/F0/cparser.cpp
@@ -1,0 +1,272 @@
+#include "cparser.hpp"
+
+#include <iostream>
+#include <map>
+#include <algorithm>
+#include <utility>
+#include "print_content.hpp"
+
+using namespace std::literals::string_literals;
+
+rychkov::CParser::CParser():
+  program_{{}}
+{
+  stack_.push(&program_[0]);
+}
+
+std::vector< rychkov::entities::Expression >::const_iterator rychkov::CParser::begin() const
+{
+  return program_.cbegin();
+}
+std::vector< rychkov::entities::Expression >::const_iterator rychkov::CParser::end() const
+{
+  return program_.cend();
+}
+const rychkov::TypeParser& rychkov::CParser::next() const
+{
+  return type_parser_;
+}
+void rychkov::CParser::prepare_type()
+{
+  type_parser_.prepare();
+}
+void rychkov::CParser::clear_program()
+{
+  program_ = {{}};
+  stack_ = {};
+  stack_.push(&program_[0]);
+  type_parser_.clear();
+}
+void rychkov::CParser::push_back(entities::Expression expr)
+{
+  program_.push_back(std::move(expr));
+}
+
+const rychkov::Operator rychkov::CParser::parentheses = {Operator::MULTIPLE, Operator::SPECIAL,
+    "()", false, false, false, 1};
+const rychkov::Operator rychkov::CParser::brackets = {Operator::BINARY, Operator::SPECIAL,
+    "[]", false, false, false, 1};
+const rychkov::Operator rychkov::CParser::comma = {Operator::BINARY, Operator::SPECIAL,
+    ",", false, false, false, 15};
+const rychkov::Operator rychkov::CParser::inline_if = {Operator::TERNARY, Operator::SPECIAL,
+    "?:", false, false, false, 13};
+
+bool rychkov::CParser::global_scope() const noexcept
+{
+  return (stack_.size() == 1) && (stack_.top()->empty());
+}
+
+void rychkov::CParser::append(CParseContext& context, entities::Literal literal)
+{
+  if (!type_parser_.empty())
+  {
+    if (literal.type != entities::Literal::Number)
+    {
+      log(context, "non-numeric literal cannot be a part of a type");
+      return;
+    }
+    try
+    {
+      type_parser_.append(context, std::stoull(literal.literal, nullptr, 0));
+    }
+    catch (...)
+    {
+      log(context, "failed to parse numeric literal");
+    }
+    return;
+  }
+  if (global_scope() || stack_.top()->full())
+  {
+    log(context, "unexpected literal");
+    return;
+  }
+  stack_.top()->operands.push_back(std::move(literal));
+}
+void rychkov::CParser::append(CParseContext& context, TypeKeyword keyword)
+{
+  (type_parser_.*(type_keywords.at(keyword)))(context);
+}
+void rychkov::CParser::append(CParseContext& context, std::string name)
+{
+  decltype(base_types)::const_iterator base_type_p = base_types.find(name);
+  if (base_type_p != base_types.cend())
+  {
+    type_parser_.append(context, base_type_p->first);
+    return;
+  }
+  decltype(aliases)::const_iterator alias_p = aliases.find(name);
+  if (alias_p != aliases.cend())
+  {
+    type_parser_.append(context, alias_p->type);
+    return;
+  }
+  if (!type_parser_.empty())
+  {
+    type_parser_.append(context, name);
+    return;
+  }
+  decltype(variables)::const_iterator var_p = variables.find(name);
+  if (var_p != variables.cend())
+  {
+    if (stack_.top()->full())
+    {
+      log(context, "unexpected variable");
+      return;
+    }
+    stack_.top()->operands.push_back(var_p->first);
+    return;
+  }
+
+  if (stack_.top()->empty())
+  {
+    log(context, "unexpected name (" + name + ")");
+    return;
+  }
+  if (entities::is_decl(*stack_.top()))
+  {
+    entities::Declaration& decl = boost::variant2::get< entities::Declaration >(stack_.top()->operands[0]);
+    if (boost::variant2::holds_alternative< entities::Struct >(decl.data))
+    {
+      entities::Struct& data = boost::variant2::get< entities::Struct >(decl.data);
+      if (data.name.empty())
+      {
+        data.name = std::move(name);
+        return;
+      }
+      log(context, "struct name duplicating (" + name + ")");
+      return;
+    }
+  }
+  log(context, "unexpected name (" + name + ")");
+}
+
+void rychkov::CParser::append(CParseContext& context, char c)
+{
+  if (!type_parser_.empty())
+  {
+    if (!type_parser_.ready() || (c == '*') || (c == '(') || (c == '['))
+    {
+      type_parser_.append(context, c);
+    }
+    else if (flush_type_parser(context))
+    {
+      append(context, c);
+    }
+    return;
+  }
+  using append_signature = void(CParser::*)(CParseContext&);
+  using append_map = std::map< char, append_signature >;
+  static const append_map dispatch_map = {
+        {';', &CParser::parse_semicolon},
+        {'{', &CParser::parse_open_brace},
+        {'}', &CParser::parse_close_brace},
+        {'(', &CParser::parse_open_parenthesis},
+        {')', &CParser::parse_close_parenthesis},
+        {'[', &CParser::parse_open_bracket},
+        {']', &CParser::parse_close_bracket},
+        {',', &CParser::parse_comma},
+        {'?', &CParser::parse_question_mark},
+        {':', &CParser::parse_colon}
+      };
+
+  append_map::const_iterator found = dispatch_map.find(c);
+  if (found != dispatch_map.cend())
+  {
+    (this->*(found->second))(context);
+    return;
+  }
+  log(context, "unknown symbol ('"s + c + "'; code = " + std::to_string(c) + ")");
+}
+bool rychkov::CParser::flush_type_parser(CParseContext& context)
+{
+  if (!type_parser_.empty())
+  {
+    if (!type_parser_.ready())
+    {
+      log(context, "type cannot be finished here");
+      return false;
+    }
+    type_parser_.prepare();
+    if (entities::is_decl(*stack_.top()))
+    {
+      entities::Declaration& decl = boost::variant2::get< entities::Declaration >(stack_.top()->operands[0]);
+      if (boost::variant2::holds_alternative< entities::Alias >(decl.data))
+      {
+        entities::Alias& alias = boost::variant2::get< entities::Alias >(decl.data);
+        if (!alias.name.empty())
+        {
+          log(context, "duplicating types in typedef declaration");
+        }
+        else if (type_parser_.is_type())
+        {
+          log(context, "missing alias name");
+        }
+        else
+        {
+          entities::Variable temp = type_parser_.variable();
+          alias = {std::move(temp.type), std::move(temp.name)};
+        }
+      }
+      type_parser_.clear();
+      return true;
+    }
+    if (type_parser_.is_function())
+    {
+      if (!global_scope())
+      {
+        log(context, "functions can be declared only in global scope");
+        type_parser_.clear();
+        return false;
+      }
+      *stack_.top() = entities::Declaration{type_parser_.function()};
+      variables.insert({type_parser_.variable(), stack_.size()});
+    }
+    else
+    {
+      if (!stack_.top()->empty())
+      {
+        log(context, "variable declaration cannot be placed here");
+        type_parser_.clear();
+        return false;
+      }
+      if (variables.find({{{}, type_parser_.name()}, stack_.size()}) != variables.end())
+      {
+        log(context, "variable name repeats in one scope");
+        type_parser_.clear();
+        return false;
+      }
+      *stack_.top() = entities::Declaration{type_parser_.variable()};
+      variables.insert({type_parser_.variable(), stack_.size()});
+    }
+  }
+  type_parser_.clear();
+  return true;
+}
+bool rychkov::CParser::append_empty(CParseContext& context)
+{
+  if (stack_.empty())
+  {
+    program_.emplace_back();
+    stack_.push(&program_.back());
+    return true;
+  }
+  if (entities::is_body(*stack_.top()))
+  {
+    entities::Body& body = boost::variant2::get< entities::Body >(stack_.top()->operands[0]);
+    body.data.emplace_back();
+    stack_.push(&body.data.back());
+    return true;
+  }
+  if (entities::is_decl(*stack_.top()))
+  {
+    entities::Declaration& decl = boost::variant2::get< entities::Declaration >(stack_.top()->operands[0]);
+    if (decl.value != nullptr)
+    {
+      stack_.pop();
+      return append_empty(context);
+    }
+    return true;
+  }
+  log(context, "cannot append any expr to this place");
+  return false;
+}

--- a/rychkov.mihail/F0/cparser.cpp
+++ b/rychkov.mihail/F0/cparser.cpp
@@ -1,7 +1,6 @@
 #include "cparser.hpp"
 
 #include <iostream>
-#include <algorithm>
 #include <utility>
 #include <map.hpp>
 #include "print_content.hpp"
@@ -29,6 +28,12 @@ const rychkov::TypeParser& rychkov::CParser::next() const
 void rychkov::CParser::prepare_type()
 {
   type_parser_.prepare();
+}
+void rychkov::CParser::prepare_to_rewrite()
+{
+  program_.clear();
+  stack_ = {};
+  type_parser_.clear();
 }
 void rychkov::CParser::clear_program()
 {

--- a/rychkov.mihail/F0/cparser.cpp
+++ b/rychkov.mihail/F0/cparser.cpp
@@ -1,9 +1,9 @@
 #include "cparser.hpp"
 
 #include <iostream>
-#include <map>
 #include <algorithm>
 #include <utility>
+#include <map.hpp>
 #include "print_content.hpp"
 
 using namespace std::literals::string_literals;
@@ -32,7 +32,8 @@ void rychkov::CParser::prepare_type()
 }
 void rychkov::CParser::clear_program()
 {
-  program_ = {{}};
+  program_.clear();
+  program_.emplace_back();
   stack_ = {};
   stack_.push(&program_[0]);
   type_parser_.clear();
@@ -124,10 +125,10 @@ void rychkov::CParser::append(CParseContext& context, std::string name)
   }
   if (entities::is_decl(*stack_.top()))
   {
-    entities::Declaration& decl = boost::variant2::get< entities::Declaration >(stack_.top()->operands[0]);
-    if (boost::variant2::holds_alternative< entities::Struct >(decl.data))
+    entities::Declaration& decl = get< entities::Declaration >(stack_.top()->operands[0]);
+    if (holds_alternative< entities::Struct >(decl.data))
     {
-      entities::Struct& data = boost::variant2::get< entities::Struct >(decl.data);
+      entities::Struct& data = get< entities::Struct >(decl.data);
       if (data.name.empty())
       {
         data.name = std::move(name);
@@ -155,7 +156,7 @@ void rychkov::CParser::append(CParseContext& context, char c)
     return;
   }
   using append_signature = void(CParser::*)(CParseContext&);
-  using append_map = std::map< char, append_signature >;
+  using append_map = Map< char, append_signature >;
   static const append_map dispatch_map = {
         {';', &CParser::parse_semicolon},
         {'{', &CParser::parse_open_brace},
@@ -189,10 +190,10 @@ bool rychkov::CParser::flush_type_parser(CParseContext& context)
     type_parser_.prepare();
     if (entities::is_decl(*stack_.top()))
     {
-      entities::Declaration& decl = boost::variant2::get< entities::Declaration >(stack_.top()->operands[0]);
-      if (boost::variant2::holds_alternative< entities::Alias >(decl.data))
+      entities::Declaration& decl = get< entities::Declaration >(stack_.top()->operands[0]);
+      if (holds_alternative< entities::Alias >(decl.data))
       {
-        entities::Alias& alias = boost::variant2::get< entities::Alias >(decl.data);
+        entities::Alias& alias = get< entities::Alias >(decl.data);
         if (!alias.name.empty())
         {
           log(context, "duplicating types in typedef declaration");
@@ -252,14 +253,14 @@ bool rychkov::CParser::append_empty(CParseContext& context)
   }
   if (entities::is_body(*stack_.top()))
   {
-    entities::Body& body = boost::variant2::get< entities::Body >(stack_.top()->operands[0]);
+    entities::Body& body = get< entities::Body >(stack_.top()->operands[0]);
     body.data.emplace_back();
     stack_.push(&body.data.back());
     return true;
   }
   if (entities::is_decl(*stack_.top()))
   {
-    entities::Declaration& decl = boost::variant2::get< entities::Declaration >(stack_.top()->operands[0]);
+    entities::Declaration& decl = get< entities::Declaration >(stack_.top()->operands[0]);
     if (decl.value != nullptr)
     {
       stack_.pop();

--- a/rychkov.mihail/F0/cparser.hpp
+++ b/rychkov.mihail/F0/cparser.hpp
@@ -1,0 +1,152 @@
+#ifndef CPARSER_HPP
+#define CPARSER_HPP
+
+#include <cstddef>
+#include <iosfwd>
+#include <string>
+#include <set>
+#include <map>
+#include <vector>
+#include <utility>
+
+#include "type_parser.hpp"
+#include "content.hpp"
+#include "compare.hpp"
+#include "log.hpp"
+
+namespace rychkov
+{
+  class CParser
+  {
+  public:
+    enum TypeKeyword
+    {
+      CONST,
+      VOLATILE,
+      SIGNED,
+      UNSIGNED,
+      LONG
+    };
+    using value_type = entities::Expression;
+
+    static const Operator parentheses;
+    static const Operator brackets;
+    static const Operator comma;
+    static const Operator inline_if;
+
+    std::set< entities::Alias, NameCompare > aliases;
+    std::multiset< std::pair< entities::Variable, size_t >, NameCompare > variables;
+    std::multiset< entities::Variable, NameCompare > defined_functions;
+
+    std::set< std::pair< entities::Struct, size_t >, NameCompare > structs;
+    std::set< std::pair< entities::Union, size_t >, NameCompare > unions;
+    std::set< std::pair< entities::Enum, size_t >, NameCompare > enums;
+    std::set< std::pair< typing::Type, size_t >, NameCompare > base_types = {
+          {{"int", typing::BASIC}, 0},
+          {{"char", typing::BASIC}, 0},
+          {{"float", typing::BASIC}, 0},
+          {{"double", typing::BASIC}, 0},
+          {{"void", typing::BASIC}, 0}
+        };
+
+    CParser();
+    CParser(const CParser&) = delete;
+    CParser(CParser&&) = default;
+
+    template< class T >
+    static void clear_scope(T& pair_set, size_t scope);
+
+    std::vector< entities::Expression >::const_iterator begin() const;
+    std::vector< entities::Expression >::const_iterator end() const;
+    const TypeParser& next() const;
+    void prepare_type();
+    void clear_program();
+    void push_back(entities::Expression expr);
+
+    void append(CParseContext& context, char c);
+    void append(CParseContext& context, entities::Literal literal);
+    void append(CParseContext& context, std::string name);
+    void append(CParseContext& context, const std::vector< rychkov::Operator >& cases);
+    void append(CParseContext& context, TypeKeyword keyword);
+
+    void parse_typedef(CParseContext& context);
+    void parse_struct(CParseContext& context);
+    void parse_union(CParseContext& context);
+    void parse_enum(CParseContext& context);
+    void parse_return(CParseContext& context);
+    void parse_if(CParseContext& context);
+    void parse_else(CParseContext& context);
+    void parse_do(CParseContext& context);
+    void parse_while(CParseContext& context);
+    void parse_for(CParseContext& context);
+
+  private:
+    static constexpr int min_priority = -1;
+
+    const std::map< TypeKeyword, void(TypeParser::*)(CParseContext&) > type_keywords = {
+          {CONST, &TypeParser::append_const},
+          {VOLATILE, &TypeParser::append_volatile},
+          {SIGNED, &TypeParser::append_signed},
+          {UNSIGNED, &TypeParser::append_unsigned},
+          {LONG, &TypeParser::append_long}
+        };
+
+    std::vector< entities::Expression > program_;
+    std::stack< entities::Expression* > stack_;
+    TypeParser type_parser_;
+
+    bool global_scope() const noexcept;
+
+    bool flush_type_parser(CParseContext& context);
+    bool append_empty(CParseContext& context);
+    entities::Expression* move_up();
+    void move_down();
+    void move_up_down();
+    void fold(CParseContext& context, const Operator* reference = nullptr);
+    void clear_scope();
+    void calculate_type(CParseContext& context, entities::Expression& expr);
+    void require_type(CParseContext& context, entities::Expression::operand& expr, const typing::Type& type);
+    void require_type(CParseContext& context, entities::Expression& expr, const typing::Type& type);
+    std::pair< const entities::Variable*, typing::MatchType > find_overload(const std::string& name,
+        const std::vector< typing::Type >& args);
+
+    void parse_semicolon(CParseContext& context);
+    void parse_open_brace(CParseContext& context);
+    void parse_close_brace(CParseContext& context);
+    void parse_open_parenthesis(CParseContext& context);
+    void parse_close_parenthesis(CParseContext& context);
+    void parse_open_bracket(CParseContext& context);
+    void parse_close_bracket(CParseContext& context);
+    void parse_comma(CParseContext& context);
+    void parse_question_mark(CParseContext& context);
+    void parse_colon(CParseContext& context);
+
+    void check_statement_placement(CParseContext& context);
+
+    bool parse_unary(CParseContext& context, const Operator& oper);
+    bool parse_binary(CParseContext& context, const Operator& oper);
+  };
+}
+
+template< class T >
+void rychkov::CParser::clear_scope(T& pair_set, size_t scope)
+{
+  typename T::iterator pos = pair_set.begin();
+  while (pos != pair_set.end())
+  {
+    if (pos->second <= scope)
+    {
+      pos = pair_set.upper_bound(entities::get_name(pos->first));
+      continue;
+    }
+    typename T::iterator to = pair_set.lower_bound({pos->first, scope});
+    if (pos == to)
+    {
+      ++pos;
+      continue;
+    }
+    pos = pair_set.erase(pos, to);
+  }
+}
+
+#endif

--- a/rychkov.mihail/F0/cparser.hpp
+++ b/rychkov.mihail/F0/cparser.hpp
@@ -61,6 +61,7 @@ namespace rychkov
     std::vector< entities::Expression >::const_iterator end() const;
     const TypeParser& next() const;
     void prepare_type();
+    void prepare_to_rewrite();
     void clear_program();
     void push_back(entities::Expression expr);
 

--- a/rychkov.mihail/F0/cparser.hpp
+++ b/rychkov.mihail/F0/cparser.hpp
@@ -6,8 +6,8 @@
 #include <string>
 #include <vector>
 #include <utility>
-#include <set>
-#include <map>
+#include <set.hpp>
+#include <map.hpp>
 #include <stack.hpp>
 
 #include "type_parser.hpp"
@@ -35,14 +35,14 @@ namespace rychkov
     static const Operator comma;
     static const Operator inline_if;
 
-    std::set< entities::Alias, NameCompare > aliases;
-    std::multiset< std::pair< entities::Variable, size_t >, NameCompare > variables;
-    std::multiset< entities::Variable, NameCompare > defined_functions;
+    Set< entities::Alias, NameCompare > aliases;
+    MultiSet< std::pair< entities::Variable, size_t >, NameCompare > variables;
+    MultiSet< entities::Variable, NameCompare > defined_functions;
 
-    std::set< std::pair< entities::Struct, size_t >, NameCompare > structs;
-    std::set< std::pair< entities::Union, size_t >, NameCompare > unions;
-    std::set< std::pair< entities::Enum, size_t >, NameCompare > enums;
-    std::set< std::pair< typing::Type, size_t >, NameCompare > base_types = {
+    Set< std::pair< entities::Struct, size_t >, NameCompare > structs;
+    Set< std::pair< entities::Union, size_t >, NameCompare > unions;
+    Set< std::pair< entities::Enum, size_t >, NameCompare > enums;
+    Set< std::pair< typing::Type, size_t >, NameCompare > base_types = {
           {{"int", typing::BASIC}, 0},
           {{"char", typing::BASIC}, 0},
           {{"float", typing::BASIC}, 0},
@@ -84,7 +84,7 @@ namespace rychkov
   private:
     static constexpr int min_priority = -1;
 
-    std::map< TypeKeyword, void(TypeParser::*)(CParseContext&) > type_keywords = {
+    Map< TypeKeyword, void(TypeParser::*)(CParseContext&) > type_keywords = {
           {CONST, &TypeParser::append_const},
           {VOLATILE, &TypeParser::append_volatile},
           {SIGNED, &TypeParser::append_signed},

--- a/rychkov.mihail/F0/cparser.hpp
+++ b/rychkov.mihail/F0/cparser.hpp
@@ -4,10 +4,11 @@
 #include <cstddef>
 #include <iosfwd>
 #include <string>
-#include <set>
-#include <map>
 #include <vector>
 #include <utility>
+#include <set>
+#include <map>
+#include <stack.hpp>
 
 #include "type_parser.hpp"
 #include "content.hpp"
@@ -83,7 +84,7 @@ namespace rychkov
   private:
     static constexpr int min_priority = -1;
 
-    const std::map< TypeKeyword, void(TypeParser::*)(CParseContext&) > type_keywords = {
+    std::map< TypeKeyword, void(TypeParser::*)(CParseContext&) > type_keywords = {
           {CONST, &TypeParser::append_const},
           {VOLATILE, &TypeParser::append_volatile},
           {SIGNED, &TypeParser::append_signed},
@@ -92,7 +93,7 @@ namespace rychkov
         };
 
     std::vector< entities::Expression > program_;
-    std::stack< entities::Expression* > stack_;
+    rychkov::Stack< entities::Expression* > stack_;
     TypeParser type_parser_;
 
     bool global_scope() const noexcept;

--- a/rychkov.mihail/F0/lexer.cpp
+++ b/rychkov.mihail/F0/lexer.cpp
@@ -1,0 +1,293 @@
+#include "lexer.hpp"
+
+#include <iostream>
+#include <cctype>
+#include <utility>
+#include "cparser.hpp"
+#include "print_content.hpp"
+
+rychkov::Lexer::Lexer(std::unique_ptr< CParser > cparser):
+  next{std::move(cparser)},
+  type_keywords_{
+        {"const", CParser::CONST},
+        {"volatile", CParser::VOLATILE},
+        {"signed", CParser::SIGNED},
+        {"unsigned", CParser::UNSIGNED},
+        {"long", CParser::LONG}
+      },
+  keywords_{
+        {"typedef", &CParser::parse_typedef},
+        {"struct", &CParser::parse_struct},
+        {"return", &CParser::parse_return},
+        {"if", &CParser::parse_if},
+        {"while", &CParser::parse_while}
+      }
+{}
+
+const std::set< std::vector< rychkov::Operator >, rychkov::NameCompare > rychkov::Lexer::cases{
+      {
+        {rychkov::Operator::UNARY, rychkov::Operator::ARITHMETIC, "+", false, true, false, 2},
+        {rychkov::Operator::BINARY, rychkov::Operator::ARITHMETIC, "+", false, false, false, 4}
+      },
+      {
+        {rychkov::Operator::UNARY, rychkov::Operator::INCREMENT, "++", true, false, false, 1},
+        {rychkov::Operator::UNARY, rychkov::Operator::INCREMENT, "++", true, true, true, 2},
+      },
+      {
+        {rychkov::Operator::UNARY, rychkov::Operator::ARITHMETIC, "-", false, true, false, 2},
+        {rychkov::Operator::BINARY, rychkov::Operator::ARITHMETIC, "-", false, false, false, 4}
+      },
+      {
+        {rychkov::Operator::UNARY, rychkov::Operator::INCREMENT, "--", true, false, false, 1},
+        {rychkov::Operator::UNARY, rychkov::Operator::INCREMENT, "--", true, true, true, 2},
+      },
+      {{rychkov::Operator::BINARY, rychkov::Operator::FIELD_ACCESS, ".", true, false, true, 1}},
+      {{rychkov::Operator::BINARY, rychkov::Operator::FIELD_ACCESS, "->", false, false, true, 1}},
+      {{rychkov::Operator::UNARY, rychkov::Operator::LOGIC, "!", false, true, false, 2}},
+      {{rychkov::Operator::UNARY, rychkov::Operator::BIT, "~", false, true, false, 2}},
+      {
+        {rychkov::Operator::UNARY, rychkov::Operator::DEREFERENCE, "*", false, true, true, 2},
+        {rychkov::Operator::BINARY, rychkov::Operator::ARITHMETIC, "*", false, false, false, 3}
+      },
+      {{rychkov::Operator::BINARY, rychkov::Operator::ARITHMETIC, "/", false, false, false, 3}},
+      {{rychkov::Operator::BINARY, rychkov::Operator::MODULUS, "%", false, false, false, 3}},
+      {{rychkov::Operator::BINARY, rychkov::Operator::BIT, "<<", false, false, false, 5}},
+      {{rychkov::Operator::BINARY, rychkov::Operator::BIT, ">>", false, false, false, 5}},
+      {{rychkov::Operator::BINARY, rychkov::Operator::COMPARE, ">", false, false, false, 6}},
+      {{rychkov::Operator::BINARY, rychkov::Operator::COMPARE, ">=", false, false, false, 6}},
+      {{rychkov::Operator::BINARY, rychkov::Operator::COMPARE, "<", false, false, false, 6}},
+      {{rychkov::Operator::BINARY, rychkov::Operator::COMPARE, "<=", false, false, false, 6}},
+      {{rychkov::Operator::BINARY, rychkov::Operator::COMPARE, "==", false, false, false, 7}},
+      {{rychkov::Operator::BINARY, rychkov::Operator::COMPARE, "!=", false, false, false, 7}},
+      {
+        {rychkov::Operator::UNARY, rychkov::Operator::ADDRESSOF, "&", true, true, false, 2},
+        {rychkov::Operator::BINARY, rychkov::Operator::BIT, "&", false, false, false, 8}
+      },
+      {{rychkov::Operator::BINARY, rychkov::Operator::BIT, "^", false, false, false, 9}},
+      {{rychkov::Operator::BINARY, rychkov::Operator::BIT, "|", false, false, false, 10}},
+      {{rychkov::Operator::BINARY, rychkov::Operator::LOGIC, "&&", false, false, false, 11}},
+      {{rychkov::Operator::BINARY, rychkov::Operator::LOGIC, "||", false, false, false, 12}},
+      {{rychkov::Operator::BINARY, rychkov::Operator::ARITHMETIC, "+=", true, true, true, 14}},
+      {{rychkov::Operator::BINARY, rychkov::Operator::ARITHMETIC, "-=", true, true, true, 14}},
+      {{rychkov::Operator::BINARY, rychkov::Operator::ARITHMETIC, "*=", true, true, true, 14}},
+      {{rychkov::Operator::BINARY, rychkov::Operator::ARITHMETIC, "/=", true, true, true, 14}},
+      {{rychkov::Operator::BINARY, rychkov::Operator::MODULUS, "%=", true, true, true, 14}},
+      {{rychkov::Operator::BINARY, rychkov::Operator::BIT, "<<=", true, true, true, 14}},
+      {{rychkov::Operator::BINARY, rychkov::Operator::BIT, ">>=", true, true, true, 14}},
+      {{rychkov::Operator::BINARY, rychkov::Operator::BIT, "&=", true, true, true, 14}},
+      {{rychkov::Operator::BINARY, rychkov::Operator::BIT, "^=", true, true, true, 14}},
+      {{rychkov::Operator::BINARY, rychkov::Operator::BIT, "|=", true, true, true, 14}},
+      {{rychkov::Operator::BINARY, rychkov::Operator::ASSIGN, "=", true, true, true, 14}}
+    };
+
+void rychkov::Lexer::append_name(CParseContext& context, std::string name)
+{
+  flush(context);
+  decltype(type_keywords_)::const_iterator type_keyword_p = type_keywords_.find(name);
+  if (type_keyword_p != type_keywords_.end())
+  {
+    if (next == nullptr)
+    {
+      context.out << "<keyw> " << name << '\n';
+    }
+    else
+    {
+      next->append(context, type_keyword_p->second);
+    }
+    return;
+  }
+  decltype(keywords_)::const_iterator keyword_p = keywords_.find(name);
+  if (keyword_p != keywords_.cend())
+  {
+    if (next == nullptr)
+    {
+      context.out << "<keyw> " << name << '\n';
+    }
+    else
+    {
+      ((*next).*(keyword_p->second))(context);
+    }
+    return;
+  }
+
+  if (next == nullptr)
+  {
+    context.out << "<name> " << name << '\n';
+  }
+  else
+  {
+    next->append(context, std::move(name));
+  }
+}
+void rychkov::Lexer::append_number(CParseContext& context, std::string name)
+{
+  flush(context);
+  bool is_int = true;
+  entities::Literal lit = {{}, {}, entities::Literal::Number};
+  std::string::size_type i = 0;
+  for (; i < name.length(); i++)
+  {
+    if (name[i] == '.')
+    {
+      if (!is_int)
+      {
+        log(context, "point duplicates in numeric literal");
+        continue;
+      }
+      is_int = false;
+      lit.literal += name[i];
+      continue;
+    }
+    if (name[i] == '\'')
+    {
+      continue;
+    }
+    if (!std::isdigit(name[i]))
+    {
+      break;
+    }
+    lit.literal += name[i];
+  }
+  lit.suffix = name.substr(i, name.length() - i);
+
+  if (is_int)
+  {
+    lit.result_type = {"int", typing::BASIC};
+  }
+  else
+  {
+    lit.result_type = {"double", typing::BASIC};
+  }
+
+  if ((lit.suffix == "f") || (lit.suffix == "F"))
+  {
+    lit.result_type.name = "float";
+  }
+  else if (!is_int)
+  {
+    if (!lit.suffix.empty())
+    {
+      log(context, "unknown numeric suffix - " + lit.suffix);
+      lit.suffix.clear();
+    }
+  }
+  else if ((lit.suffix == "l") || (lit.suffix == "L"))
+  {
+    lit.result_type.length_category = typing::LONG;
+  }
+  else if ((lit.suffix == "ul") || (lit.suffix == "UL"))
+  {
+    lit.result_type.length_category = typing::LONG;
+    lit.result_type.is_unsigned = true;
+  }
+  else if ((lit.suffix == "ll") || (lit.suffix == "LL"))
+  {
+    lit.result_type.length_category = typing::LONG_LONG;
+  }
+  else if ((lit.suffix == "ull") || (lit.suffix == "ULL"))
+  {
+    lit.result_type.length_category = typing::LONG_LONG;
+    lit.result_type.is_unsigned = true;
+  }
+  else if (!lit.suffix.empty())
+  {
+    log(context, "unknown numeric suffix - " + lit.suffix);
+    lit.suffix.clear();
+  }
+
+  if (next == nullptr)
+  {
+    context.out << "<numb> " << lit << '\n';
+  }
+  else
+  {
+    next->append(context, lit);
+  }
+}
+void rychkov::Lexer::append_string_literal(CParseContext& context, std::string name)
+{
+  flush(context);
+  name.erase(name.length() - 1);
+  name.erase(0, 1);
+  typing::Type type = {{}, typing::ARRAY, {"char", typing::BASIC, nullptr, true}};
+  buf_ = entities::Literal{name, {}, entities::Literal::String, std::move(type)};
+}
+void rychkov::Lexer::append_char_literal(CParseContext& context, std::string name)
+{
+  flush(context);
+  name.erase(name.length() - 1);
+  name.erase(0, 1);
+  buf_ = entities::Literal{name, {}, entities::Literal::String, {"char", typing::BASIC, nullptr, true}};
+}
+void rychkov::Lexer::flush(CParseContext& context)
+{
+  if (boost::variant2::holds_alternative< entities::Literal >(buf_))
+  {
+    entities::Literal& lit = boost::variant2::get< entities::Literal >(buf_);
+    if (lit.type == entities::Literal::String)
+    {
+      lit.result_type.array_has_length = true;
+      lit.result_type.array_length = lit.literal.length() + 1;
+    }
+
+    if (next == nullptr)
+    {
+      context.out << "<lit>  " << lit << '\n';
+    }
+    else
+    {
+      next->append(context, lit);
+    }
+  }
+  else if (boost::variant2::holds_alternative< operator_value >(buf_))
+  {
+    if (next == nullptr)
+    {
+      context.out << "<oper> " << (*boost::variant2::get< operator_value >(buf_))[0].token << '\n';
+    }
+    else
+    {
+      next->append(context, *boost::variant2::get< operator_value >(buf_));
+    }
+  }
+  buf_.emplace< 0 >();
+}
+void rychkov::Lexer::append(CParseContext& context, char c)
+{
+  if (boost::variant2::holds_alternative< operator_value >(buf_))
+  {
+    append_operator(context, c);
+    return;
+  }
+  flush(context);
+  append_new(context, c);
+}
+void rychkov::Lexer::append_new(CParseContext& context, char c)
+{
+  decltype(cases)::const_iterator oper_p = cases.find(std::string{c});
+  if (oper_p != cases.end())
+  {
+    buf_ = &*oper_p;
+  }
+  else if (!std::isspace(c))
+  {
+    if (next == nullptr)
+    {
+      context.out << "<spec> " << c << '\n';
+      return;
+    }
+    next->append(context, c);
+  }
+}
+void rychkov::Lexer::append_operator(CParseContext& context, char c)
+{
+  operator_value& oper = boost::variant2::get< operator_value >(buf_);
+  decltype(cases)::const_iterator oper_p = cases.find((*oper)[0].token + c);
+  if (oper_p != cases.cend())
+  {
+    buf_ = &*oper_p;
+    return;
+  }
+  flush(context);
+  append(context, c);
+}

--- a/rychkov.mihail/F0/lexer.cpp
+++ b/rychkov.mihail/F0/lexer.cpp
@@ -24,60 +24,60 @@ rychkov::Lexer::Lexer(std::unique_ptr< CParser > cparser):
       }
 {}
 
-const std::set< std::vector< rychkov::Operator >, rychkov::NameCompare > rychkov::Lexer::cases{
+const rychkov::Set< std::vector< rychkov::Operator >, rychkov::NameCompare > rychkov::Lexer::cases{
       {
-        {rychkov::Operator::UNARY, rychkov::Operator::ARITHMETIC, "+", false, true, false, 2},
-        {rychkov::Operator::BINARY, rychkov::Operator::ARITHMETIC, "+", false, false, false, 4}
+        {Operator::UNARY, Operator::ARITHMETIC, "+", false, true, false, 2},
+        {Operator::BINARY, Operator::ARITHMETIC, "+", false, false, false, 4}
       },
       {
-        {rychkov::Operator::UNARY, rychkov::Operator::INCREMENT, "++", true, false, false, 1},
-        {rychkov::Operator::UNARY, rychkov::Operator::INCREMENT, "++", true, true, true, 2},
+        {Operator::UNARY, Operator::INCREMENT, "++", true, false, false, 1},
+        {Operator::UNARY, Operator::INCREMENT, "++", true, true, true, 2},
       },
       {
-        {rychkov::Operator::UNARY, rychkov::Operator::ARITHMETIC, "-", false, true, false, 2},
-        {rychkov::Operator::BINARY, rychkov::Operator::ARITHMETIC, "-", false, false, false, 4}
+        {Operator::UNARY, Operator::ARITHMETIC, "-", false, true, false, 2},
+        {Operator::BINARY, Operator::ARITHMETIC, "-", false, false, false, 4}
       },
       {
-        {rychkov::Operator::UNARY, rychkov::Operator::INCREMENT, "--", true, false, false, 1},
-        {rychkov::Operator::UNARY, rychkov::Operator::INCREMENT, "--", true, true, true, 2},
+        {Operator::UNARY, Operator::INCREMENT, "--", true, false, false, 1},
+        {Operator::UNARY, Operator::INCREMENT, "--", true, true, true, 2},
       },
-      {{rychkov::Operator::BINARY, rychkov::Operator::FIELD_ACCESS, ".", true, false, true, 1}},
-      {{rychkov::Operator::BINARY, rychkov::Operator::FIELD_ACCESS, "->", false, false, true, 1}},
-      {{rychkov::Operator::UNARY, rychkov::Operator::LOGIC, "!", false, true, false, 2}},
-      {{rychkov::Operator::UNARY, rychkov::Operator::BIT, "~", false, true, false, 2}},
+      {{Operator::BINARY, Operator::FIELD_ACCESS, ".", true, false, true, 1}},
+      {{Operator::BINARY, Operator::FIELD_ACCESS, "->", false, false, true, 1}},
+      {{Operator::UNARY, Operator::LOGIC, "!", false, true, false, 2}},
+      {{Operator::UNARY, Operator::BIT, "~", false, true, false, 2}},
       {
-        {rychkov::Operator::UNARY, rychkov::Operator::DEREFERENCE, "*", false, true, true, 2},
-        {rychkov::Operator::BINARY, rychkov::Operator::ARITHMETIC, "*", false, false, false, 3}
+        {Operator::UNARY, Operator::DEREFERENCE, "*", false, true, true, 2},
+        {Operator::BINARY, Operator::ARITHMETIC, "*", false, false, false, 3}
       },
-      {{rychkov::Operator::BINARY, rychkov::Operator::ARITHMETIC, "/", false, false, false, 3}},
-      {{rychkov::Operator::BINARY, rychkov::Operator::MODULUS, "%", false, false, false, 3}},
-      {{rychkov::Operator::BINARY, rychkov::Operator::BIT, "<<", false, false, false, 5}},
-      {{rychkov::Operator::BINARY, rychkov::Operator::BIT, ">>", false, false, false, 5}},
-      {{rychkov::Operator::BINARY, rychkov::Operator::COMPARE, ">", false, false, false, 6}},
-      {{rychkov::Operator::BINARY, rychkov::Operator::COMPARE, ">=", false, false, false, 6}},
-      {{rychkov::Operator::BINARY, rychkov::Operator::COMPARE, "<", false, false, false, 6}},
-      {{rychkov::Operator::BINARY, rychkov::Operator::COMPARE, "<=", false, false, false, 6}},
-      {{rychkov::Operator::BINARY, rychkov::Operator::COMPARE, "==", false, false, false, 7}},
-      {{rychkov::Operator::BINARY, rychkov::Operator::COMPARE, "!=", false, false, false, 7}},
+      {{Operator::BINARY, Operator::ARITHMETIC, "/", false, false, false, 3}},
+      {{Operator::BINARY, Operator::MODULUS, "%", false, false, false, 3}},
+      {{Operator::BINARY, Operator::BIT, "<<", false, false, false, 5}},
+      {{Operator::BINARY, Operator::BIT, ">>", false, false, false, 5}},
+      {{Operator::BINARY, Operator::COMPARE, ">", false, false, false, 6}},
+      {{Operator::BINARY, Operator::COMPARE, ">=", false, false, false, 6}},
+      {{Operator::BINARY, Operator::COMPARE, "<", false, false, false, 6}},
+      {{Operator::BINARY, Operator::COMPARE, "<=", false, false, false, 6}},
+      {{Operator::BINARY, Operator::COMPARE, "==", false, false, false, 7}},
+      {{Operator::BINARY, Operator::COMPARE, "!=", false, false, false, 7}},
       {
-        {rychkov::Operator::UNARY, rychkov::Operator::ADDRESSOF, "&", true, true, false, 2},
-        {rychkov::Operator::BINARY, rychkov::Operator::BIT, "&", false, false, false, 8}
+        {Operator::UNARY, Operator::ADDRESSOF, "&", true, true, false, 2},
+        {Operator::BINARY, Operator::BIT, "&", false, false, false, 8}
       },
-      {{rychkov::Operator::BINARY, rychkov::Operator::BIT, "^", false, false, false, 9}},
-      {{rychkov::Operator::BINARY, rychkov::Operator::BIT, "|", false, false, false, 10}},
-      {{rychkov::Operator::BINARY, rychkov::Operator::LOGIC, "&&", false, false, false, 11}},
-      {{rychkov::Operator::BINARY, rychkov::Operator::LOGIC, "||", false, false, false, 12}},
-      {{rychkov::Operator::BINARY, rychkov::Operator::ARITHMETIC, "+=", true, true, true, 14}},
-      {{rychkov::Operator::BINARY, rychkov::Operator::ARITHMETIC, "-=", true, true, true, 14}},
-      {{rychkov::Operator::BINARY, rychkov::Operator::ARITHMETIC, "*=", true, true, true, 14}},
-      {{rychkov::Operator::BINARY, rychkov::Operator::ARITHMETIC, "/=", true, true, true, 14}},
-      {{rychkov::Operator::BINARY, rychkov::Operator::MODULUS, "%=", true, true, true, 14}},
-      {{rychkov::Operator::BINARY, rychkov::Operator::BIT, "<<=", true, true, true, 14}},
-      {{rychkov::Operator::BINARY, rychkov::Operator::BIT, ">>=", true, true, true, 14}},
-      {{rychkov::Operator::BINARY, rychkov::Operator::BIT, "&=", true, true, true, 14}},
-      {{rychkov::Operator::BINARY, rychkov::Operator::BIT, "^=", true, true, true, 14}},
-      {{rychkov::Operator::BINARY, rychkov::Operator::BIT, "|=", true, true, true, 14}},
-      {{rychkov::Operator::BINARY, rychkov::Operator::ASSIGN, "=", true, true, true, 14}}
+      {{Operator::BINARY, Operator::BIT, "^", false, false, false, 9}},
+      {{Operator::BINARY, Operator::BIT, "|", false, false, false, 10}},
+      {{Operator::BINARY, Operator::LOGIC, "&&", false, false, false, 11}},
+      {{Operator::BINARY, Operator::LOGIC, "||", false, false, false, 12}},
+      {{Operator::BINARY, Operator::ARITHMETIC, "+=", true, true, true, 14}},
+      {{Operator::BINARY, Operator::ARITHMETIC, "-=", true, true, true, 14}},
+      {{Operator::BINARY, Operator::ARITHMETIC, "*=", true, true, true, 14}},
+      {{Operator::BINARY, Operator::ARITHMETIC, "/=", true, true, true, 14}},
+      {{Operator::BINARY, Operator::MODULUS, "%=", true, true, true, 14}},
+      {{Operator::BINARY, Operator::BIT, "<<=", true, true, true, 14}},
+      {{Operator::BINARY, Operator::BIT, ">>=", true, true, true, 14}},
+      {{Operator::BINARY, Operator::BIT, "&=", true, true, true, 14}},
+      {{Operator::BINARY, Operator::BIT, "^=", true, true, true, 14}},
+      {{Operator::BINARY, Operator::BIT, "|=", true, true, true, 14}},
+      {{Operator::BINARY, Operator::ASSIGN, "=", true, true, true, 14}}
     };
 
 void rychkov::Lexer::append_name(CParseContext& context, std::string name)
@@ -221,9 +221,9 @@ void rychkov::Lexer::append_char_literal(CParseContext& context, std::string nam
 }
 void rychkov::Lexer::flush(CParseContext& context)
 {
-  if (boost::variant2::holds_alternative< entities::Literal >(buf_))
+  if (holds_alternative< entities::Literal >(buf_))
   {
-    entities::Literal& lit = boost::variant2::get< entities::Literal >(buf_);
+    entities::Literal& lit = get< entities::Literal >(buf_);
     if (lit.type == entities::Literal::String)
     {
       lit.result_type.array_has_length = true;
@@ -239,22 +239,22 @@ void rychkov::Lexer::flush(CParseContext& context)
       next->append(context, lit);
     }
   }
-  else if (boost::variant2::holds_alternative< operator_value >(buf_))
+  else if (holds_alternative< operator_value >(buf_))
   {
     if (next == nullptr)
     {
-      context.out << "<oper> " << (*boost::variant2::get< operator_value >(buf_))[0].token << '\n';
+      context.out << "<oper> " << (*get< operator_value >(buf_))[0].token << '\n';
     }
     else
     {
-      next->append(context, *boost::variant2::get< operator_value >(buf_));
+      next->append(context, *get< operator_value >(buf_));
     }
   }
   buf_.emplace< 0 >();
 }
 void rychkov::Lexer::append(CParseContext& context, char c)
 {
-  if (boost::variant2::holds_alternative< operator_value >(buf_))
+  if (holds_alternative< operator_value >(buf_))
   {
     append_operator(context, c);
     return;
@@ -281,7 +281,7 @@ void rychkov::Lexer::append_new(CParseContext& context, char c)
 }
 void rychkov::Lexer::append_operator(CParseContext& context, char c)
 {
-  operator_value& oper = boost::variant2::get< operator_value >(buf_);
+  operator_value& oper = get< operator_value >(buf_);
   decltype(cases)::const_iterator oper_p = cases.find((*oper)[0].token + c);
   if (oper_p != cases.cend())
   {

--- a/rychkov.mihail/F0/lexer.hpp
+++ b/rychkov.mihail/F0/lexer.hpp
@@ -1,0 +1,46 @@
+#ifndef LEXER_HPP
+#define LEXER_HPP
+
+#include <string>
+#include <set>
+#include <map>
+#include <vector>
+#include <memory>
+#include <boost/variant2.hpp>
+
+#include "content.hpp"
+#include "compare.hpp"
+#include "log.hpp"
+#include "cparser.hpp"
+
+namespace rychkov
+{
+  class Lexer
+  {
+  public:
+    static const std::set< std::vector< Operator >, NameCompare > cases;
+    std::unique_ptr< CParser > next;
+
+    Lexer(std::unique_ptr< CParser > cparser = nullptr);
+
+    void append_name(CParseContext& context, std::string name);
+    void append_number(CParseContext& context, std::string name);
+    void append_string_literal(CParseContext& context, std::string name);
+    void append_char_literal(CParseContext& context, std::string name);
+    void append(CParseContext& context, char c);
+    void flush(CParseContext& context);
+
+  private:
+    using operator_value = const std::vector< Operator >*;
+
+    const std::map< std::string, CParser::TypeKeyword > type_keywords_;
+    const std::map< std::string, void(CParser::*)(CParseContext&) > keywords_;
+
+    boost::variant2::variant< boost::variant2::monostate, operator_value, entities::Literal > buf_;
+
+    void append_new(CParseContext& context, char c);
+    void append_operator(CParseContext& context, char c);
+  };
+}
+
+#endif

--- a/rychkov.mihail/F0/lexer.hpp
+++ b/rychkov.mihail/F0/lexer.hpp
@@ -33,8 +33,8 @@ namespace rychkov
   private:
     using operator_value = const std::vector< Operator >*;
 
-    const std::map< std::string, CParser::TypeKeyword > type_keywords_;
-    const std::map< std::string, void(CParser::*)(CParseContext&) > keywords_;
+    std::map< std::string, CParser::TypeKeyword > type_keywords_;
+    std::map< std::string, void(CParser::*)(CParseContext&) > keywords_;
 
     boost::variant2::variant< boost::variant2::monostate, operator_value, entities::Literal > buf_;
 

--- a/rychkov.mihail/F0/lexer.hpp
+++ b/rychkov.mihail/F0/lexer.hpp
@@ -2,11 +2,11 @@
 #define LEXER_HPP
 
 #include <string>
-#include <set>
-#include <map>
 #include <vector>
 #include <memory>
-#include <boost/variant2.hpp>
+#include <set.hpp>
+#include <map.hpp>
+#include <variant.hpp>
 
 #include "content.hpp"
 #include "compare.hpp"
@@ -18,7 +18,7 @@ namespace rychkov
   class Lexer
   {
   public:
-    static const std::set< std::vector< Operator >, NameCompare > cases;
+    static const Set< std::vector< Operator >, NameCompare > cases;
     std::unique_ptr< CParser > next;
 
     Lexer(std::unique_ptr< CParser > cparser = nullptr);
@@ -33,10 +33,10 @@ namespace rychkov
   private:
     using operator_value = const std::vector< Operator >*;
 
-    std::map< std::string, CParser::TypeKeyword > type_keywords_;
-    std::map< std::string, void(CParser::*)(CParseContext&) > keywords_;
+    Map< std::string, CParser::TypeKeyword > type_keywords_;
+    Map< std::string, void(CParser::*)(CParseContext&) > keywords_;
 
-    boost::variant2::variant< boost::variant2::monostate, operator_value, entities::Literal > buf_;
+    Variant< Monostate, operator_value, entities::Literal > buf_;
 
     void append_new(CParseContext& context, char c);
     void append_operator(CParseContext& context, char c);

--- a/rychkov.mihail/F0/log.cpp
+++ b/rychkov.mihail/F0/log.cpp
@@ -1,0 +1,28 @@
+#include "log.hpp"
+
+#include <iostream>
+
+void rychkov::log(CParseContext& context, std::string message)
+{
+  start_log(context) << message;
+  finish_log(context);
+}
+std::ostream& rychkov::start_log(CParseContext& context)
+{
+  context.err << (context.macro_expansion ? "In expansion of macro \"" : "In file \"") << context.file;
+  context.err << "\" (" << context.line + 1 << ':' << context.symbol + 1 << ")\n";
+  context.err << "\tError: ";
+  return context.err;
+}
+void rychkov::finish_log(CParseContext& context)
+{
+  context.err << "\n  ";
+  context.err << context.last_line << "\n  " << std::string(context.symbol, '-') << "^\n";
+  for (const CParseContext* file = context.base; file != nullptr; file = file->base)
+  {
+    context.err << (file->macro_expansion ? "Required from expansion of macro \"" : "Included from \"");
+    context.err << file->file << "\" (" << file->line + 1 << ':' << file->symbol + 1 << ")\n  ";
+    context.err << file->last_line << "\n  " << std::string(file->symbol, '-') << "^\n";
+  }
+  context.nerrors++;
+}

--- a/rychkov.mihail/F0/log.hpp
+++ b/rychkov.mihail/F0/log.hpp
@@ -1,0 +1,26 @@
+#ifndef LOG_HPP
+#define LOG_HPP
+
+#include <cstddef>
+#include <iosfwd>
+#include <string>
+
+namespace rychkov
+{
+  struct CParseContext
+  {
+    std::ostream& out;
+    std::ostream& err;
+    std::string file;
+    CParseContext* base = nullptr;
+    bool macro_expansion = false;
+    size_t line = 0, symbol = 0;
+    std::string last_line;
+    size_t nerrors = 0;
+  };
+  void log(CParseContext& context, std::string message);
+  std::ostream& start_log(CParseContext& context);
+  void finish_log(CParseContext& context);
+}
+
+#endif

--- a/rychkov.mihail/F0/main.cpp
+++ b/rychkov.mihail/F0/main.cpp
@@ -1,0 +1,24 @@
+﻿#include <iostream>
+#include <exception>
+#include "main_processor.hpp"
+
+int main(int argc, char** argv)
+{
+  try
+  {
+    rychkov::ParserContext context{std::cin, std::cout, std::cerr};
+    rychkov::MainProcessor processor;
+    if (!processor.init(context, argc, argv))
+    {
+      return 0;
+    }
+
+    while (rychkov::Parser::parse(context, processor, rychkov::MainProcessor::call_map))
+    {}
+  }
+  catch (const std::exception& e)
+  {
+    std::cerr << e.what() << '\n';
+    return 1;
+  }
+}

--- a/rychkov.mihail/F0/main_processor.cpp
+++ b/rychkov.mihail/F0/main_processor.cpp
@@ -5,7 +5,7 @@
 #include <sstream>
 #include <cctype>
 #include <utility>
-#include <algorithm>
+#include <algorithm.hpp>
 
 rychkov::Parser::map_type< rychkov::MainProcessor > rychkov::MainProcessor::call_map = {
       {"save", &rychkov::MainProcessor::save},
@@ -233,10 +233,10 @@ bool rychkov::MainProcessor::unopen_defines(ParserContext& context)
       }
     };
     std::getline(preprocessed, line);
-    std::string::iterator from = std::find_if(line.begin(), line.end(), is_name_char{});
+    std::string::iterator from = find_if(line.begin(), line.end(), is_name_char{});
     while (from != line.end())
     {
-      std::string::iterator to = std::find_if_not(from, line.end(), is_name_char{});
+      std::string::iterator to = find_if_not(from, line.end(), is_name_char{});
       std::string name{from, to};
       if ((preproc.macros.find(name) != preproc.macros.end())
             || (preproc.legacy_macros.find(name) != preproc.legacy_macros.end()))
@@ -245,7 +245,7 @@ bool rychkov::MainProcessor::unopen_defines(ParserContext& context)
         std::cout << line << '\n';
         nfound++;
       }
-      from = std::find_if(to, line.end(), is_name_char{});
+      from = find_if(to, line.end(), is_name_char{});
     }
     line_number++;
   }

--- a/rychkov.mihail/F0/main_processor.cpp
+++ b/rychkov.mihail/F0/main_processor.cpp
@@ -72,7 +72,7 @@ bool rychkov::MainProcessor::reload(ParserContext& context)
   {
     return false;
   }
-  std::map< std::string, ParseCell > new_parsed;
+  Map< std::string, ParseCell > new_parsed;
   for (const std::pair< const std::string, ParseCell >& file: parsed_)
   {
     if (!file.second.real_file)

--- a/rychkov.mihail/F0/main_processor.cpp
+++ b/rychkov.mihail/F0/main_processor.cpp
@@ -1,0 +1,254 @@
+#include "main_processor.hpp"
+
+#include <iostream>
+#include <fstream>
+#include <sstream>
+#include <cctype>
+#include <utility>
+#include <algorithm>
+
+rychkov::Parser::map_type< rychkov::MainProcessor > rychkov::MainProcessor::call_map = {
+      {"save", &rychkov::MainProcessor::save},
+      {"load", &rychkov::MainProcessor::load},
+      {"reload-all", &rychkov::MainProcessor::reload},
+      {"parse", &rychkov::MainProcessor::parse},
+      {"parse-after", &rychkov::MainProcessor::parse_after},
+      {"tree", &rychkov::MainProcessor::tree},
+      {"files", &rychkov::MainProcessor::files},
+      {"external", &rychkov::MainProcessor::external},
+      {"exposition", &rychkov::MainProcessor::exposition},
+      {"defines", &rychkov::MainProcessor::defines},
+      {"dependencies", &rychkov::MainProcessor::dependencies},
+      {"uses", &rychkov::MainProcessor::uses},
+      {"intersections", &rychkov::MainProcessor::intersections},
+      {"diff", &rychkov::MainProcessor::diff},
+      {"unopen-defines", &rychkov::MainProcessor::unopen_defines}
+    };
+
+rychkov::ParseCell::ParseCell(CParseContext context, Stage last_stage,
+    std::vector< std::string > include_dirs):
+  base_context{std::move(context)},
+  preproc{std::unique_ptr< Lexer >{last_stage == PREPROCESSOR ? nullptr : new Lexer
+        {std::unique_ptr< CParser >{last_stage != CPARSER ? nullptr : new CParser{}}}},
+      std::move(include_dirs)}
+{}
+bool rychkov::ParseCell::parse(std::istream& in)
+{
+  std::stringstream cache_stream;
+  cache_stream << in.rdbuf();
+  cache = cache_stream.str();
+  preproc.parse(base_context, cache_stream);
+  return base_context.nerrors == 0;
+}
+
+bool rychkov::MainProcessor::parse(ParserContext& context)
+{
+  std::string filename;
+  if (!(context.in >> filename) || !eol(context.in))
+  {
+    return false;
+  }
+  std::ifstream in(filename);
+  if (!in)
+  {
+    context.err << "failed to open file\n";
+    return true;
+  }
+  ParseCell cell = {{context.out, context.err, filename}, last_stage_, include_dirs_};
+  context.out << "<--PARSE: \"" << filename << "\"-->\n";
+  if (!cell.parse(in))
+  {
+    context.err << "failed to parse file \"" << filename << "\" - stopping\n";
+    return true;
+  }
+  context.out << "<--DONE-->\n";
+  parsed_.erase(filename);
+  parsed_.emplace(filename, std::move(cell));
+  return true;
+}
+bool rychkov::MainProcessor::reload(ParserContext& context)
+{
+  if (!eol(context.in))
+  {
+    return false;
+  }
+  std::map< std::string, ParseCell > new_parsed;
+  for (const std::pair< const std::string, ParseCell >& file: parsed_)
+  {
+    if (!file.second.real_file)
+    {
+      continue;
+    }
+    std::ifstream in(file.first);
+    if (!in)
+    {
+      context.err << "failed to reopen source file: \"" << file.first << "\"\n";
+    }
+    std::pair< decltype(new_parsed)::iterator, bool > cell_p = new_parsed.emplace(file.first,
+          ParseCell{{context.out, context.err, file.first}, last_stage_, include_dirs_});
+    if (cell_p.second)
+    {
+      context.out << "<--PARSE: \"" << file.first << "\"-->\n";
+      if (!cell_p.first->second.parse(in))
+      {
+        context.err << "failed to parse file \"" << file.first << "\" - stopping\n";
+        return true;
+      }
+    }
+  }
+  context.out << "<--DONE-->\n";
+  parsed_ = std::move(new_parsed);
+  generated_files = 0;
+  return true;
+}
+bool rychkov::MainProcessor::parse_after(ParserContext& context)
+{
+  std::string generated_name = "untitled_" + std::to_string(generated_files + 1);
+  ParseCell cell = {{context.out, context.err, generated_name}, last_stage_, include_dirs_};
+  cell.real_file = false;
+  if (!eol(context.in))
+  {
+    std::string after;
+    context.in >> after;
+    const CParser& src_parser = *parsed_.at(after).preproc.next->next;
+    if (!context.in || !eol(context.in))
+    {
+      return false;
+    }
+    CParser& dest_parser = *cell.preproc.next->next;
+    dest_parser.aliases = src_parser.aliases;
+    dest_parser.variables = src_parser.variables;
+    dest_parser.structs = src_parser.structs;
+    dest_parser.enums = src_parser.enums;
+    dest_parser.unions = src_parser.unions;
+  }
+  while (context.in.good())
+  {
+    cell.base_context.symbol = 0;
+    std::getline(context.in, cell.base_context.last_line);
+    std::string::size_type eof_tag = cell.base_context.last_line.find("$EOF");
+    if (eof_tag != std::string::npos)
+    {
+      cell.base_context.last_line.erase(eof_tag);
+    }
+    cell.cache += cell.base_context.last_line;
+    cell.cache += '\n';
+    for (char c: cell.base_context.last_line)
+    {
+      cell.preproc.append(cell.base_context, c);
+      cell.base_context.symbol++;
+    }
+    if (eof_tag == std::string::npos)
+    {
+      cell.preproc.append(cell.base_context, '\n');
+      cell.base_context.line++;
+    }
+    else
+    {
+      break;
+    }
+  }
+  cell.preproc.flush(cell.base_context);
+  if (cell.base_context.nerrors > 0)
+  {
+    context.err << "failed to parse - delete temporary\n";
+    return true;
+  }
+  context.out << "<--GENERETED: \"" << generated_name << "\"-->\n";
+  generated_files++;
+  parsed_.emplace(generated_name, std::move(cell));
+  return true;
+}
+
+bool rychkov::MainProcessor::save(ParserContext& context)
+{
+  std::string result;
+  if (!eol(context.in))
+  {
+    context.in >> result;
+    if (!context.in || !eol(context.in))
+    {
+      return false;
+    }
+  }
+  else
+  {
+    result = save_file_;
+  }
+  if (save(context.err, result))
+  {
+    context.out << "saved to \"" << result << "\"\n";
+  }
+  return true;
+}
+bool rychkov::MainProcessor::load(ParserContext& context)
+{
+  std::string source;
+  if (!eol(context.in))
+  {
+    context.in >> source;
+    if (!context.in || !eol(context.in))
+    {
+      return false;
+    }
+  }
+  else
+  {
+    source = save_file_;
+  }
+  context.out << "load from \"" << source << "\"\n";
+  if (load(context.out, context.err, source))
+  {
+    context.out << "<--DONE-->\n";
+  }
+  return true;
+}
+bool rychkov::MainProcessor::unopen_defines(ParserContext& context)
+{
+  std::string filename;
+  if ((last_stage_ != CPARSER) || !(context.in >> filename))
+  {
+    return false;
+  }
+  const ParseCell& cell = parsed_.at(filename);
+  if (!eol(context.in))
+  {
+    return false;
+  }
+  std::istringstream in(cell.cache);
+  std::stringstream preprocessed;
+  Preprocessor preproc{nullptr, include_dirs_};
+  CParseContext parse_context{preprocessed, context.err, cell.base_context.file};
+  preproc.parse(parse_context, in);
+  std::string line;
+  size_t line_number = 1;
+  size_t nfound = 0;
+  while (preprocessed.good())
+  {
+    struct is_name_char
+    {
+      bool operator()(unsigned char c)
+      {
+        return (c == '_') || std::isalnum(c);
+      }
+    };
+    std::getline(preprocessed, line);
+    std::string::iterator from = std::find_if(line.begin(), line.end(), is_name_char{});
+    while (from != line.end())
+    {
+      std::string::iterator to = std::find_if_not(from, line.end(), is_name_char{});
+      std::string name{from, to};
+      if ((preproc.macros.find(name) != preproc.macros.end())
+            || (preproc.legacy_macros.find(name) != preproc.legacy_macros.end()))
+      {
+        std::cout << "* found macro name \"" << name << "\" on line " << line_number << ":\n";
+        std::cout << line << '\n';
+        nfound++;
+      }
+      from = std::find_if(to, line.end(), is_name_char{});
+    }
+    line_number++;
+  }
+  std::cout << "* summary: found " << nfound << " unopen macro names\n";
+  return true;
+}

--- a/rychkov.mihail/F0/main_processor.hpp
+++ b/rychkov.mihail/F0/main_processor.hpp
@@ -4,8 +4,8 @@
 #include <iosfwd>
 #include <string>
 #include <vector>
-#include <map>
 
+#include <map.hpp>
 #include <parser.hpp>
 
 #include "log.hpp"

--- a/rychkov.mihail/F0/main_processor.hpp
+++ b/rychkov.mihail/F0/main_processor.hpp
@@ -1,0 +1,71 @@
+#ifndef PROCESSORS_HPP
+#define PROCESSORS_HPP
+
+#include <iosfwd>
+#include <string>
+#include <vector>
+#include <map>
+
+#include <parser.hpp>
+
+#include "log.hpp"
+#include "preprocessor.hpp"
+
+namespace rychkov
+{
+  enum Stage
+  {
+    PREPROCESSOR,
+    LEXER,
+    CPARSER
+  };
+  struct ParseCell
+  {
+    ParseCell(CParseContext context, Stage last_stage, std::vector< std::string > include_dirs);
+    bool parse(std::istream& in);
+    CParseContext base_context;
+    Preprocessor preproc;
+    bool real_file = true;
+    std::string cache;
+  };
+
+  class MainProcessor
+  {
+  public:
+    static constexpr const char* help_file = "help.txt";
+    static Parser::map_type< MainProcessor > call_map;
+
+    void help(std::ostream& out);
+    bool parse(CParseContext file_context, bool overwrite);
+    bool load(std::ostream& out, std::ostream& err, std::string filename);
+    bool save(std::ostream& err, std::string filename) const;
+
+    bool init(ParserContext& context, int argc, char** argv);
+    bool save(ParserContext& context);
+    bool load(ParserContext& context);
+    bool reload(ParserContext& context);
+    bool parse(ParserContext& context);
+    bool parse_after(ParserContext& context);
+
+    bool external(ParserContext& context);
+    bool exposition(ParserContext& context);
+    bool defines(ParserContext& context);
+    bool tree(ParserContext& context);
+    bool files(ParserContext& context);
+
+    bool dependencies(ParserContext& context);
+    bool uses(ParserContext& context);
+    bool intersections(ParserContext& context);
+    bool diff(ParserContext& context);
+    bool unopen_defines(ParserContext& context);
+
+  private:
+    Stage last_stage_ = CPARSER;
+    std::vector< std::string > include_dirs_;
+    std::map< std::string, ParseCell > parsed_;
+    std::string save_file_ = "save.json";
+    size_t generated_files = 0;
+  };
+}
+
+#endif

--- a/rychkov.mihail/F0/main_processor.hpp
+++ b/rychkov.mihail/F0/main_processor.hpp
@@ -62,7 +62,7 @@ namespace rychkov
   private:
     Stage last_stage_ = CPARSER;
     std::vector< std::string > include_dirs_;
-    std::map< std::string, ParseCell > parsed_;
+    Map< std::string, ParseCell > parsed_;
     std::string save_file_ = "save.json";
     size_t generated_files = 0;
   };

--- a/rychkov.mihail/F0/main_processor_deependencies.cpp
+++ b/rychkov.mihail/F0/main_processor_deependencies.cpp
@@ -1,0 +1,326 @@
+#include "main_processor.hpp"
+
+#include <iostream>
+#include <algorithm>
+#include <set>
+#include <map>
+#include "compare.hpp"
+#include "print_content.hpp"
+
+namespace rychkov
+{
+  struct DependencyVisitor
+  {
+    std::ostream& out;
+    std::string symbol;
+    bool search_uses = false;
+    bool started = false;
+    std::set< std::pair< std::string, size_t >, NameCompare > actives;
+    std::string current;
+    std::map< std::string, std::set< entities::Variable, NameCompare > > dep_map;
+    std::set< entities::Variable, NameCompare > result;
+    size_t depth = 0;
+
+    bool operator()(const typing::Type& type);
+    bool operator()(const entities::Variable& var);
+    bool operator()(const entities::Declaration& decl);
+    bool operator()(const entities::Literal& literal);
+    bool operator()(const entities::CastOperation& cast);
+    bool operator()(const DynMemWrapper< entities::Expression >& root);
+    bool operator()(const entities::Expression::operand& operand);
+    bool operator()(const entities::Expression& root);
+    bool operator()(const entities::Body& body);
+    template< class Entity >
+    bool operator()(const std::vector< Entity >& sequence);
+
+    void prepare_deps(const decltype(dep_map)::mapped_type& level);
+  };
+}
+
+bool rychkov::MainProcessor::dependencies(ParserContext& context)
+{
+  std::string filename, symbol;
+  if ((last_stage_ != CPARSER) || !(context.in >> filename >> symbol))
+  {
+    return false;
+  }
+  const CParser& parser = *parsed_.at(filename).preproc.next->next;
+  if (!eol(context.in))
+  {
+    return false;
+  }
+  DependencyVisitor visitor = std::for_each(parser.begin(), parser.end(),
+        DependencyVisitor{context.out, std::move(symbol)});
+  if (!visitor.started)
+  {
+    context.out << "no symbol \"" << visitor.symbol << "\" in file \"" << filename << "\"\n";
+  }
+  else
+  {
+    context.out << "depend from:\n";
+    visitor.prepare_deps(visitor.dep_map[visitor.symbol]);
+    std::for_each(visitor.result.begin(), visitor.result.end(), ContentPrinter{context.out, 1});
+  }
+  return true;
+}
+bool rychkov::MainProcessor::uses(ParserContext& context)
+{
+  std::string filename, symbol;
+  if ((last_stage_ != CPARSER) || !(context.in >> filename >> symbol))
+  {
+    return false;
+  }
+  const CParser& parser = *parsed_.at(filename).preproc.next->next;
+  if (!eol(context.in))
+  {
+    return false;
+  }
+  if (!std::for_each(parser.begin(), parser.end(), DependencyVisitor{context.out, symbol, true}).started)
+  {
+    context.out << "no symbol \"" << symbol << "\" in file \"" << filename << "\"\n";
+  }
+  return true;
+}
+
+bool rychkov::DependencyVisitor::operator()(const entities::Variable& var)
+{
+  if (actives.find(var.name) == actives.end())
+  {
+    if (search_uses)
+    {
+      return var.name == symbol;
+    }
+    dep_map[current].insert(var);
+  }
+  return false;
+}
+bool rychkov::DependencyVisitor::operator()(const typing::Type& type)
+{
+  if (!search_uses)
+  {
+    return false;
+  }
+  if (typing::is_function(&type))
+  {
+    return operator()(*type.base) || std::any_of(type.function_parameters.begin(),
+          type.function_parameters.end(), *this);
+  }
+  return type.base == nullptr ? type.name == symbol : operator()(*type.base);
+}
+bool rychkov::DependencyVisitor::operator()(const entities::Declaration& decl)
+{
+  ++depth;
+  if (boost::variant2::holds_alternative< entities::Statement >(decl.data))
+  {
+    const entities::Statement& statement = boost::variant2::get< entities::Statement >(decl.data);
+    if (operator()(statement.conditions))
+    {
+      CParser::clear_scope(actives, --depth);
+      return true;
+    }
+  }
+  else if (boost::variant2::holds_alternative< entities::Variable >(decl.data))
+  {
+    const entities::Variable& var = boost::variant2::get< entities::Variable >(decl.data);
+    if (depth == 1)
+    {
+      current = var.name;
+      if (var.name == symbol)
+      {
+        out << var << '\n';
+        started = true;
+        if (!search_uses)
+        {
+          actives.emplace(var.name, depth - 1);
+          operator()(decl.value);
+          CParser::clear_scope(actives, --depth);
+          return true;
+        }
+      }
+      else if (!started && search_uses)
+      {
+        CParser::clear_scope(actives, --depth);
+        return false;
+      }
+    }
+    else
+    {
+      actives.emplace(var.name, depth - 1);
+    }
+    if (search_uses && operator()(var.type))
+    {
+      if (--depth == 0)
+      {
+        out << '\t' << var << '\n';
+      }
+      return true;
+    }
+  }
+  else if (boost::variant2::holds_alternative< entities::Function >(decl.data))
+  {
+    const entities::Function& func = boost::variant2::get< entities::Function >(decl.data);
+    for (const std::string& param: func.parameters)
+    {
+      if (!param.empty())
+      {
+        actives.emplace(param, depth);
+      }
+    }
+    if (depth == 1)
+    {
+      current = func.name;
+      if (func.name == symbol)
+      {
+        out << func << '\n';
+        started = true;
+        if (!search_uses)
+        {
+          actives.emplace(func.name, depth - 1);
+        }
+      }
+      else if (!started && search_uses)
+      {
+        CParser::clear_scope(actives, --depth);
+        return false;
+      }
+    }
+    else
+    {
+      actives.emplace(func.name, depth - 1);
+    }
+    if (search_uses && operator()(func.type))
+    {
+      if (--depth == 0)
+      {
+        out << '\t' << func << '\n';
+      }
+      return true;
+    }
+  }
+  else if (search_uses)
+  {
+    const std::string* name = nullptr;
+    if (boost::variant2::holds_alternative< entities::Struct >(decl.data))
+    {
+      name = &boost::variant2::get< entities::Struct >(decl.data).name;
+    }
+    else if (boost::variant2::holds_alternative< entities::Enum >(decl.data))
+    {
+      name = &boost::variant2::get< entities::Enum >(decl.data).name;
+    }
+    else if (boost::variant2::holds_alternative< entities::Union >(decl.data))
+    {
+      name = &boost::variant2::get< entities::Union >(decl.data).name;
+    }
+    if (name != nullptr)
+    {
+      if (depth == 1)
+      {
+        if (*name == symbol)
+        {
+          out << "struct-like " << *name << '\n';
+          started = true;
+        }
+      }
+      else
+      {
+        actives.emplace(*name, depth - 1);
+      }
+    }
+  }
+  if (operator()(decl.value))
+  {
+    if (depth > 1)
+    {
+      CParser::clear_scope(actives, --depth);
+      return true;
+    }
+    const std::string* name = nullptr;
+    if (search_uses && boost::variant2::holds_alternative< entities::Variable >(decl.data))
+    {
+      const entities::Variable& var = boost::variant2::get< entities::Variable >(decl.data);
+      out << '\t' << var << '\n';
+    }
+    else if (search_uses && boost::variant2::holds_alternative< entities::Function >(decl.data))
+    {
+      const entities::Function& func = boost::variant2::get< entities::Function >(decl.data);
+      out << '\t' << func << '\n';
+    }
+    else if (boost::variant2::holds_alternative< entities::Struct >(decl.data))
+    {
+      name = &boost::variant2::get< entities::Struct >(decl.data).name;
+    }
+    else if (boost::variant2::holds_alternative< entities::Enum >(decl.data))
+    {
+      name = &boost::variant2::get< entities::Enum >(decl.data).name;
+    }
+    else if (boost::variant2::holds_alternative< entities::Union >(decl.data))
+    {
+      name = &boost::variant2::get< entities::Union >(decl.data).name;
+    }
+    if (name != nullptr)
+    {
+      out << "\tstruct-like " << *name << '\n';
+    }
+  }
+  CParser::clear_scope(actives, --depth);
+  return false;
+}
+bool rychkov::DependencyVisitor::operator()(const entities::Literal&)
+{
+  return false;
+}
+bool rychkov::DependencyVisitor::operator()(const entities::CastOperation& cast)
+{
+  return operator()(cast.expr);
+}
+bool rychkov::DependencyVisitor::operator()(const DynMemWrapper< entities::Expression >& root)
+{
+  return (root != nullptr) && operator()(*root);
+}
+bool rychkov::DependencyVisitor::operator()(const entities::Expression::operand& operand)
+{
+  return boost::variant2::visit(*this, operand);
+}
+bool rychkov::DependencyVisitor::operator()(const entities::Expression& root)
+{
+  for (const entities::Expression::operand& operand: root.operands)
+  {
+    if (operator()(operand))
+    {
+      return true;
+    }
+  }
+  return false;
+}
+bool rychkov::DependencyVisitor::operator()(const entities::Body& body)
+{
+  return operator()(body.data);
+}
+template< class Entity >
+bool rychkov::DependencyVisitor::operator()(const std::vector< Entity >& sequence)
+{
+  ++depth;
+  for (const Entity& operand: sequence)
+  {
+    if (operator()(operand))
+    {
+      CParser::clear_scope(actives, --depth);
+      return true;
+    }
+  }
+  CParser::clear_scope(actives, --depth);
+  return false;
+}
+void rychkov::DependencyVisitor::prepare_deps(const decltype(dep_map)::mapped_type& level)
+{
+  for (const entities::Variable& var: level)
+  {
+    decltype(result)::iterator existing = result.find(var);
+    if (existing == result.end())
+    {
+      result.insert(var);
+      prepare_deps(dep_map[var.name]);
+    }
+  }
+}

--- a/rychkov.mihail/F0/main_processor_deependencies.cpp
+++ b/rychkov.mihail/F0/main_processor_deependencies.cpp
@@ -1,7 +1,7 @@
 #include "main_processor.hpp"
 
 #include <iostream>
-#include <algorithm>
+#include <algorithm.hpp>
 #include <set.hpp>
 #include <map.hpp>
 #include "compare.hpp"
@@ -49,7 +49,7 @@ bool rychkov::MainProcessor::dependencies(ParserContext& context)
   {
     return false;
   }
-  DependencyVisitor visitor = std::for_each(parser.begin(), parser.end(),
+  DependencyVisitor visitor = for_each(parser.begin(), parser.end(),
         DependencyVisitor{context.out, std::move(symbol)});
   if (!visitor.started)
   {
@@ -59,7 +59,7 @@ bool rychkov::MainProcessor::dependencies(ParserContext& context)
   {
     context.out << "depend from:\n";
     visitor.prepare_deps(visitor.dep_map[visitor.symbol]);
-    std::for_each(visitor.result.begin(), visitor.result.end(), ContentPrinter{context.out, 1});
+    for_each(visitor.result.begin(), visitor.result.end(), ContentPrinter{context.out, 1});
   }
   return true;
 }
@@ -75,7 +75,7 @@ bool rychkov::MainProcessor::uses(ParserContext& context)
   {
     return false;
   }
-  if (!std::for_each(parser.begin(), parser.end(), DependencyVisitor{context.out, symbol, true}).started)
+  if (!for_each(parser.begin(), parser.end(), DependencyVisitor{context.out, symbol, true}).started)
   {
     context.out << "no symbol \"" << symbol << "\" in file \"" << filename << "\"\n";
   }
@@ -102,8 +102,18 @@ bool rychkov::DependencyVisitor::operator()(const typing::Type& type)
   }
   if (typing::is_function(&type))
   {
-    return operator()(*type.base) || std::any_of(type.function_parameters.begin(),
-          type.function_parameters.end(), *this);
+    if (operator()(*type.base))
+    {
+      return true;
+    }
+    for (const typing::Type& param: type.function_parameters)
+    {
+      if (operator()(param))
+      {
+        return true;
+      }
+    }
+    return false;
   }
   return type.base == nullptr ? type.name == symbol : operator()(*type.base);
 }

--- a/rychkov.mihail/F0/main_processor_deependencies.cpp
+++ b/rychkov.mihail/F0/main_processor_deependencies.cpp
@@ -2,8 +2,8 @@
 
 #include <iostream>
 #include <algorithm>
-#include <set>
-#include <map>
+#include <set.hpp>
+#include <map.hpp>
 #include "compare.hpp"
 #include "print_content.hpp"
 
@@ -15,10 +15,10 @@ namespace rychkov
     std::string symbol;
     bool search_uses = false;
     bool started = false;
-    std::set< std::pair< std::string, size_t >, NameCompare > actives;
+    Set< std::pair< std::string, size_t >, NameCompare > actives;
     std::string current;
-    std::map< std::string, std::set< entities::Variable, NameCompare > > dep_map;
-    std::set< entities::Variable, NameCompare > result;
+    Map< std::string, Set< entities::Variable, NameCompare > > dep_map;
+    Set< entities::Variable, NameCompare > result;
     size_t depth = 0;
 
     bool operator()(const typing::Type& type);
@@ -110,18 +110,18 @@ bool rychkov::DependencyVisitor::operator()(const typing::Type& type)
 bool rychkov::DependencyVisitor::operator()(const entities::Declaration& decl)
 {
   ++depth;
-  if (boost::variant2::holds_alternative< entities::Statement >(decl.data))
+  if (holds_alternative< entities::Statement >(decl.data))
   {
-    const entities::Statement& statement = boost::variant2::get< entities::Statement >(decl.data);
+    const entities::Statement& statement = get< entities::Statement >(decl.data);
     if (operator()(statement.conditions))
     {
       CParser::clear_scope(actives, --depth);
       return true;
     }
   }
-  else if (boost::variant2::holds_alternative< entities::Variable >(decl.data))
+  else if (holds_alternative< entities::Variable >(decl.data))
   {
-    const entities::Variable& var = boost::variant2::get< entities::Variable >(decl.data);
+    const entities::Variable& var = get< entities::Variable >(decl.data);
     if (depth == 1)
     {
       current = var.name;
@@ -156,9 +156,9 @@ bool rychkov::DependencyVisitor::operator()(const entities::Declaration& decl)
       return true;
     }
   }
-  else if (boost::variant2::holds_alternative< entities::Function >(decl.data))
+  else if (holds_alternative< entities::Function >(decl.data))
   {
-    const entities::Function& func = boost::variant2::get< entities::Function >(decl.data);
+    const entities::Function& func = get< entities::Function >(decl.data);
     for (const std::string& param: func.parameters)
     {
       if (!param.empty())
@@ -200,17 +200,17 @@ bool rychkov::DependencyVisitor::operator()(const entities::Declaration& decl)
   else if (search_uses)
   {
     const std::string* name = nullptr;
-    if (boost::variant2::holds_alternative< entities::Struct >(decl.data))
+    if (holds_alternative< entities::Struct >(decl.data))
     {
-      name = &boost::variant2::get< entities::Struct >(decl.data).name;
+      name = &get< entities::Struct >(decl.data).name;
     }
-    else if (boost::variant2::holds_alternative< entities::Enum >(decl.data))
+    else if (holds_alternative< entities::Enum >(decl.data))
     {
-      name = &boost::variant2::get< entities::Enum >(decl.data).name;
+      name = &get< entities::Enum >(decl.data).name;
     }
-    else if (boost::variant2::holds_alternative< entities::Union >(decl.data))
+    else if (holds_alternative< entities::Union >(decl.data))
     {
-      name = &boost::variant2::get< entities::Union >(decl.data).name;
+      name = &get< entities::Union >(decl.data).name;
     }
     if (name != nullptr)
     {
@@ -236,27 +236,27 @@ bool rychkov::DependencyVisitor::operator()(const entities::Declaration& decl)
       return true;
     }
     const std::string* name = nullptr;
-    if (search_uses && boost::variant2::holds_alternative< entities::Variable >(decl.data))
+    if (search_uses && holds_alternative< entities::Variable >(decl.data))
     {
-      const entities::Variable& var = boost::variant2::get< entities::Variable >(decl.data);
+      const entities::Variable& var = get< entities::Variable >(decl.data);
       out << '\t' << var << '\n';
     }
-    else if (search_uses && boost::variant2::holds_alternative< entities::Function >(decl.data))
+    else if (search_uses && holds_alternative< entities::Function >(decl.data))
     {
-      const entities::Function& func = boost::variant2::get< entities::Function >(decl.data);
+      const entities::Function& func = get< entities::Function >(decl.data);
       out << '\t' << func << '\n';
     }
-    else if (boost::variant2::holds_alternative< entities::Struct >(decl.data))
+    else if (holds_alternative< entities::Struct >(decl.data))
     {
-      name = &boost::variant2::get< entities::Struct >(decl.data).name;
+      name = &get< entities::Struct >(decl.data).name;
     }
-    else if (boost::variant2::holds_alternative< entities::Enum >(decl.data))
+    else if (holds_alternative< entities::Enum >(decl.data))
     {
-      name = &boost::variant2::get< entities::Enum >(decl.data).name;
+      name = &get< entities::Enum >(decl.data).name;
     }
-    else if (boost::variant2::holds_alternative< entities::Union >(decl.data))
+    else if (holds_alternative< entities::Union >(decl.data))
     {
-      name = &boost::variant2::get< entities::Union >(decl.data).name;
+      name = &get< entities::Union >(decl.data).name;
     }
     if (name != nullptr)
     {
@@ -280,7 +280,7 @@ bool rychkov::DependencyVisitor::operator()(const DynMemWrapper< entities::Expre
 }
 bool rychkov::DependencyVisitor::operator()(const entities::Expression::operand& operand)
 {
-  return boost::variant2::visit(*this, operand);
+  return visit(*this, operand);
 }
 bool rychkov::DependencyVisitor::operator()(const entities::Expression& root)
 {

--- a/rychkov.mihail/F0/main_processor_diff.cpp
+++ b/rychkov.mihail/F0/main_processor_diff.cpp
@@ -1,0 +1,195 @@
+#include "main_processor.hpp"
+
+#include <iostream>
+#include <map>
+#include <vector>
+#include <algorithm>
+#include <utility>
+#include "compare.hpp"
+#include "print_content.hpp"
+
+namespace rychkov
+{
+  struct DiffVisitor
+  {
+    std::set< std::string > files;
+    std::multimap< entities::Variable, std::vector< std::string >, NameCompare > appearances;
+    std::multimap< Macro, std::vector< std::string >, NameCompare > macros;
+    std::string current_file;
+
+    void operator()(const std::pair< const std::string, ParseCell >& cell)
+    {
+      current_file = cell.first;
+      if (!files.empty() && (files.find(current_file) == files.end()))
+      {
+        return;
+      }
+      const Preprocessor& preproc = cell.second.preproc;
+      const CParser& parser = *preproc.next->next;
+      *this = std::for_each(parser.begin(), parser.end(), std::move(*this));
+      *this = std::for_each(preproc.macros.begin(), preproc.macros.end(), std::move(*this));
+      *this = std::for_each(preproc.legacy_macros.begin(), preproc.legacy_macros.end(), std::move(*this));
+    }
+    void operator()(const entities::Expression& expr)
+    {
+      if (entities::is_decl(expr))
+      {
+        const entities::Declaration& decl = boost::variant2::get< entities::Declaration >(expr.operands[0]);
+        entities::Variable declared;
+        if (boost::variant2::holds_alternative< entities::Variable >(decl.data))
+        {
+          operator()(boost::variant2::get< entities::Variable >(decl.data));
+        }
+        else if (boost::variant2::holds_alternative< entities::Function >(decl.data))
+        {
+          const entities::Function& func = boost::variant2::get< entities::Function >(decl.data);
+          operator()({func.type, func.name});
+        }
+      }
+    }
+    void operator()(const entities::Variable& var)
+    {
+      using Iter = decltype(appearances)::iterator;
+      std::pair< Iter, Iter > range = appearances.equal_range(var);
+      for (; range.first != range.second; ++range.first)
+      {
+        if (var.name != range.first->first.name)
+        {}
+        else if (!typing::exact_cv(range.first->first.type, var.type))
+        {}
+        else if (range.first->second.empty() || (range.first->second.back() != current_file))
+        {
+          range.first->second.push_back(current_file);
+          break;
+        }
+      }
+      if (range.first == range.second)
+      {
+        appearances.emplace(var, std::vector< std::string >{current_file});
+      }
+    }
+    void operator()(const Macro& macro)
+    {
+      using Iter = decltype(macros)::iterator;
+      std::pair< Iter, Iter > range = macros.equal_range(macro);
+      for (; range.first != range.second; ++range.first)
+      {
+        const std::vector< std::string >& parameters = range.first->first.parameters;
+        if (macro.name != range.first->first.name)
+        {}
+        else if (macro.func_style != range.first->first.func_style)
+        {}
+        else if (!std::equal(parameters.begin(), parameters.end(),
+              macro.parameters.begin(), macro.parameters.end()))
+        {}
+        else if (macro.body != range.first->first.body)
+        {}
+        else if (range.first->second.empty() || (range.first->second.back() != current_file))
+        {
+          range.first->second.push_back(current_file);
+          break;
+        }
+      }
+      if (range.first == range.second)
+      {
+        macros.emplace(macro, std::vector< std::string >{current_file});
+      }
+    }
+  };
+}
+
+bool rychkov::MainProcessor::intersections(ParserContext& context)
+{
+  if ((last_stage_ != CPARSER) || !eol(context.in))
+  {
+    return false;
+  }
+  DiffVisitor visitor = std::for_each(parsed_.begin(), parsed_.end(), DiffVisitor{});
+  bool empty = true;
+  for (const decltype(visitor.appearances)::value_type& list: visitor.appearances)
+  {
+    if (list.second.size() >= 2)
+    {
+      empty = false;
+      ContentPrinter{context.out, 0}(list.first);
+      std::for_each(list.second.begin(), list.second.end(), ContentPrinter{context.out, 1});
+    }
+  }
+  for (const decltype(visitor.macros)::value_type& list: visitor.macros)
+  {
+    if (list.second.size() >= 2)
+    {
+      empty = false;
+      ContentPrinter{context.out, 0}(list.first);
+      std::for_each(list.second.begin(), list.second.end(), ContentPrinter{context.out, 1});
+    }
+  }
+  if (empty)
+  {
+    context.out << "no identical symbols in file\n";
+  }
+  return true;
+}
+bool rychkov::MainProcessor::diff(ParserContext& context)
+{
+  std::set< std::string > files;
+  if (last_stage_ != CPARSER)
+  {
+    return false;
+  }
+  while (!eol(context.in))
+  {
+    std::string name;
+    context.in >> name;
+    files.insert(name);
+  }
+  DiffVisitor visitor = std::for_each(parsed_.begin(), parsed_.end(), DiffVisitor{std::move(files)});
+  bool empty = true;
+  using MacroIter = decltype(visitor.macros)::const_iterator;
+  MacroIter i = visitor.macros.begin();
+  while (i != visitor.macros.end())
+  {
+    MacroIter to = visitor.macros.upper_bound(i->first.name);
+    if (std::distance(i, to) > 1)
+    {
+      empty = false;
+      ContentPrinter{context.out, 0}(i->first.name);
+      std::set< std::string > files_list;
+      for (; i != to; ++i)
+      {
+        files_list.insert(i->second.begin(), i->second.end());
+      }
+      std::for_each(files_list.begin(), files_list.end(), ContentPrinter{context.out, 1});
+    }
+    else
+    {
+      ++i;
+    }
+  }
+  using VarIter = decltype(visitor.appearances)::const_iterator;
+  VarIter j = visitor.appearances.begin();
+  while (j != visitor.appearances.end())
+  {
+    VarIter to = visitor.appearances.upper_bound(j->first.name);
+    if (std::distance(j, to) > 1)
+    {
+      empty = false;
+      ContentPrinter{context.out, 0}(j->first.name);
+      std::set< std::string > files_list;
+      for (; j != to; ++j)
+      {
+        files_list.insert(j->second.begin(), j->second.end());
+      }
+      std::for_each(files_list.begin(), files_list.end(), ContentPrinter{context.out, 1});
+    }
+    else
+    {
+      ++j;
+    }
+  }
+  if (empty)
+  {
+    context.out << "no diff symbols in file\n";
+  }
+  return true;
+}

--- a/rychkov.mihail/F0/main_processor_diff.cpp
+++ b/rychkov.mihail/F0/main_processor_diff.cpp
@@ -2,8 +2,8 @@
 
 #include <iostream>
 #include <vector>
-#include <algorithm>
 #include <utility>
+#include <algorithm.hpp>
 #include <map.hpp>
 #include "compare.hpp"
 #include "print_content.hpp"
@@ -26,9 +26,9 @@ namespace rychkov
       }
       const Preprocessor& preproc = cell.second.preproc;
       const CParser& parser = *preproc.next->next;
-      *this = std::for_each(parser.begin(), parser.end(), std::move(*this));
-      *this = std::for_each(preproc.macros.begin(), preproc.macros.end(), std::move(*this));
-      *this = std::for_each(preproc.legacy_macros.begin(), preproc.legacy_macros.end(), std::move(*this));
+      *this = for_each(parser.begin(), parser.end(), std::move(*this));
+      *this = for_each(preproc.macros.begin(), preproc.macros.end(), std::move(*this));
+      *this = for_each(preproc.legacy_macros.begin(), preproc.legacy_macros.end(), std::move(*this));
     }
     void operator()(const entities::Expression& expr)
     {
@@ -104,7 +104,7 @@ bool rychkov::MainProcessor::intersections(ParserContext& context)
   {
     return false;
   }
-  DiffVisitor visitor = std::for_each(parsed_.begin(), parsed_.end(), DiffVisitor{});
+  DiffVisitor visitor = for_each(parsed_.begin(), parsed_.end(), DiffVisitor{});
   bool empty = true;
   for (const decltype(visitor.appearances)::value_type& list: visitor.appearances)
   {
@@ -112,7 +112,7 @@ bool rychkov::MainProcessor::intersections(ParserContext& context)
     {
       empty = false;
       ContentPrinter{context.out, 0}(list.first);
-      std::for_each(list.second.begin(), list.second.end(), ContentPrinter{context.out, 1});
+      for_each(list.second.begin(), list.second.end(), ContentPrinter{context.out, 1});
     }
   }
   for (const decltype(visitor.macros)::value_type& list: visitor.macros)
@@ -121,7 +121,7 @@ bool rychkov::MainProcessor::intersections(ParserContext& context)
     {
       empty = false;
       ContentPrinter{context.out, 0}(list.first);
-      std::for_each(list.second.begin(), list.second.end(), ContentPrinter{context.out, 1});
+      for_each(list.second.begin(), list.second.end(), ContentPrinter{context.out, 1});
     }
   }
   if (empty)
@@ -143,7 +143,7 @@ bool rychkov::MainProcessor::diff(ParserContext& context)
     context.in >> name;
     files.insert(name);
   }
-  DiffVisitor visitor = std::for_each(parsed_.begin(), parsed_.end(), DiffVisitor{std::move(files)});
+  DiffVisitor visitor = for_each(parsed_.begin(), parsed_.end(), DiffVisitor{std::move(files)});
   bool empty = true;
   using MacroIter = decltype(visitor.macros)::const_iterator;
   MacroIter i = visitor.macros.begin();
@@ -159,7 +159,7 @@ bool rychkov::MainProcessor::diff(ParserContext& context)
       {
         files_list.insert(i->second.begin(), i->second.end());
       }
-      std::for_each(files_list.begin(), files_list.end(), ContentPrinter{context.out, 1});
+      for_each(files_list.begin(), files_list.end(), ContentPrinter{context.out, 1});
     }
     else
     {
@@ -180,7 +180,7 @@ bool rychkov::MainProcessor::diff(ParserContext& context)
       {
         files_list.insert(j->second.begin(), j->second.end());
       }
-      std::for_each(files_list.begin(), files_list.end(), ContentPrinter{context.out, 1});
+      for_each(files_list.begin(), files_list.end(), ContentPrinter{context.out, 1});
     }
     else
     {

--- a/rychkov.mihail/F0/main_processor_diff.cpp
+++ b/rychkov.mihail/F0/main_processor_diff.cpp
@@ -1,10 +1,10 @@
 #include "main_processor.hpp"
 
 #include <iostream>
-#include <map>
 #include <vector>
 #include <algorithm>
 #include <utility>
+#include <map.hpp>
 #include "compare.hpp"
 #include "print_content.hpp"
 
@@ -12,9 +12,9 @@ namespace rychkov
 {
   struct DiffVisitor
   {
-    std::set< std::string > files;
-    std::multimap< entities::Variable, std::vector< std::string >, NameCompare > appearances;
-    std::multimap< Macro, std::vector< std::string >, NameCompare > macros;
+    Set< std::string > files;
+    MultiMap< entities::Variable, std::vector< std::string >, NameCompare > appearances;
+    MultiMap< Macro, std::vector< std::string >, NameCompare > macros;
     std::string current_file;
 
     void operator()(const std::pair< const std::string, ParseCell >& cell)
@@ -34,15 +34,15 @@ namespace rychkov
     {
       if (entities::is_decl(expr))
       {
-        const entities::Declaration& decl = boost::variant2::get< entities::Declaration >(expr.operands[0]);
+        const entities::Declaration& decl = get< entities::Declaration >(expr.operands[0]);
         entities::Variable declared;
-        if (boost::variant2::holds_alternative< entities::Variable >(decl.data))
+        if (holds_alternative< entities::Variable >(decl.data))
         {
-          operator()(boost::variant2::get< entities::Variable >(decl.data));
+          operator()(get< entities::Variable >(decl.data));
         }
-        else if (boost::variant2::holds_alternative< entities::Function >(decl.data))
+        else if (holds_alternative< entities::Function >(decl.data))
         {
-          const entities::Function& func = boost::variant2::get< entities::Function >(decl.data);
+          const entities::Function& func = get< entities::Function >(decl.data);
           operator()({func.type, func.name});
         }
       }
@@ -132,7 +132,7 @@ bool rychkov::MainProcessor::intersections(ParserContext& context)
 }
 bool rychkov::MainProcessor::diff(ParserContext& context)
 {
-  std::set< std::string > files;
+  Set< std::string > files;
   if (last_stage_ != CPARSER)
   {
     return false;
@@ -154,7 +154,7 @@ bool rychkov::MainProcessor::diff(ParserContext& context)
     {
       empty = false;
       ContentPrinter{context.out, 0}(i->first.name);
-      std::set< std::string > files_list;
+      Set< std::string > files_list;
       for (; i != to; ++i)
       {
         files_list.insert(i->second.begin(), i->second.end());
@@ -175,7 +175,7 @@ bool rychkov::MainProcessor::diff(ParserContext& context)
     {
       empty = false;
       ContentPrinter{context.out, 0}(j->first.name);
-      std::set< std::string > files_list;
+      Set< std::string > files_list;
       for (; j != to; ++j)
       {
         files_list.insert(j->second.begin(), j->second.end());

--- a/rychkov.mihail/F0/main_processor_info.cpp
+++ b/rychkov.mihail/F0/main_processor_info.cpp
@@ -1,0 +1,126 @@
+#include "main_processor.hpp"
+
+#include <fstream>
+#include <algorithm>
+#include "print_content.hpp"
+
+void rychkov::MainProcessor::help(std::ostream& out)
+{
+  std::ifstream file(help_file);
+  if (!file)
+  {
+    out << "failed to open help file - \"" << help_file << "\"\n";
+    return;
+  }
+  out << file.rdbuf();
+}
+bool rychkov::MainProcessor::files(ParserContext& context)
+{
+  if (!eol(context.in))
+  {
+    return false;
+  }
+  ContentPrinter printer{context.out};
+  for (const decltype(parsed_)::value_type& i: parsed_)
+  {
+    printer(i.first);
+  }
+  return true;
+}
+bool rychkov::MainProcessor::tree(ParserContext& context)
+{
+  std::string filename;
+  if ((last_stage_ != CPARSER) || !(context.in >> filename))
+  {
+    return false;
+  }
+  const CParser& parser = *parsed_.at(filename).preproc.next->next;
+  if (!eol(context.in))
+  {
+    return false;
+  }
+  std::for_each(parser.begin(), parser.end(), ContentPrinter{context.out});
+  return true;
+}
+bool rychkov::MainProcessor::external(ParserContext& context)
+{
+  if ((last_stage_ != CPARSER) || !eol(context.in))
+  {
+    return false;
+  }
+  ContentPrinter printer{context.out};
+  bool no_external = true;
+  for (const std::pair< const std::string, ParseCell >& cell: parsed_)
+  {
+    for (const entities::Expression& expr: *cell.second.preproc.next->next)
+    {
+      if (entities::is_decl(expr))
+      {
+        const entities::Declaration& decl = boost::variant2::get< entities::Declaration >(expr.operands[0]);
+        if (decl.scope == entities::EXTERN)
+        {
+          printer(decl);
+          no_external = false;
+        }
+      }
+    }
+  }
+  if (no_external)
+  {
+    context.out << "no external symbols\n";
+  }
+  return true;
+}
+bool rychkov::MainProcessor::exposition(ParserContext& context)
+{
+  std::string filename, structure;
+  if ((last_stage_ != CPARSER) || !(context.in >> filename >> structure))
+  {
+    return false;
+  }
+  const CParser& parser = *parsed_.at(filename).preproc.next->next;
+  if (!eol(context.in))
+  {
+    return false;
+  }
+  decltype(parser.structs)::iterator struct_p = parser.structs.find(structure);
+  decltype(parser.unions)::iterator union_p = parser.unions.find(structure);
+  decltype(parser.enums)::iterator enum_p = parser.enums.find(structure);
+  ContentPrinter printer(context.out);
+  if (struct_p != parser.structs.end())
+  {
+    printer(struct_p->first);
+  }
+  else if (union_p != parser.unions.end())
+  {
+    printer(union_p->first);
+  }
+  else if (enum_p != parser.enums.end())
+  {
+    printer(enum_p->first);
+  }
+  else
+  {
+    context.out << "no struct/enum/union with name \"" << structure << "\" in file \"" << filename << "\"\n";
+  }
+  return true;
+}
+bool rychkov::MainProcessor::defines(ParserContext& context)
+{
+  std::string filename;
+  if ((last_stage_ != CPARSER) || !(context.in >> filename))
+  {
+    return false;
+  }
+  const Preprocessor& preproc = parsed_.at(filename).preproc;
+  if (!eol(context.in))
+  {
+    return false;
+  }
+  ContentPrinter printer(context.out, 1);
+  context.out << "<actual>:\n";
+  std::for_each(preproc.macros.begin(), preproc.macros.end(), printer);
+  context.out << "<legacy>:\n";
+  std::for_each(preproc.legacy_macros.begin(), preproc.legacy_macros.end(), printer);
+  return true;
+}

--- a/rychkov.mihail/F0/main_processor_info.cpp
+++ b/rychkov.mihail/F0/main_processor_info.cpp
@@ -1,7 +1,7 @@
 #include "main_processor.hpp"
 
 #include <fstream>
-#include <algorithm>
+#include <algorithm.hpp>
 #include "print_content.hpp"
 
 void rychkov::MainProcessor::help(std::ostream& out)
@@ -39,7 +39,7 @@ bool rychkov::MainProcessor::tree(ParserContext& context)
   {
     return false;
   }
-  std::for_each(parser.begin(), parser.end(), ContentPrinter{context.out});
+  for_each(parser.begin(), parser.end(), ContentPrinter{context.out});
   return true;
 }
 bool rychkov::MainProcessor::external(ParserContext& context)
@@ -119,8 +119,8 @@ bool rychkov::MainProcessor::defines(ParserContext& context)
   }
   ContentPrinter printer(context.out, 1);
   context.out << "<actual>:\n";
-  std::for_each(preproc.macros.begin(), preproc.macros.end(), printer);
+  for_each(preproc.macros.begin(), preproc.macros.end(), printer);
   context.out << "<legacy>:\n";
-  std::for_each(preproc.legacy_macros.begin(), preproc.legacy_macros.end(), printer);
+  for_each(preproc.legacy_macros.begin(), preproc.legacy_macros.end(), printer);
   return true;
 }

--- a/rychkov.mihail/F0/main_processor_info.cpp
+++ b/rychkov.mihail/F0/main_processor_info.cpp
@@ -56,7 +56,7 @@ bool rychkov::MainProcessor::external(ParserContext& context)
     {
       if (entities::is_decl(expr))
       {
-        const entities::Declaration& decl = boost::variant2::get< entities::Declaration >(expr.operands[0]);
+        const entities::Declaration& decl = get< entities::Declaration >(expr.operands[0]);
         if (decl.scope == entities::EXTERN)
         {
           printer(decl);
@@ -83,9 +83,9 @@ bool rychkov::MainProcessor::exposition(ParserContext& context)
   {
     return false;
   }
-  decltype(parser.structs)::iterator struct_p = parser.structs.find(structure);
-  decltype(parser.unions)::iterator union_p = parser.unions.find(structure);
-  decltype(parser.enums)::iterator enum_p = parser.enums.find(structure);
+  decltype(parser.structs)::const_iterator struct_p = parser.structs.find(structure);
+  decltype(parser.unions)::const_iterator union_p = parser.unions.find(structure);
+  decltype(parser.enums)::const_iterator enum_p = parser.enums.find(structure);
   ContentPrinter printer(context.out);
   if (struct_p != parser.structs.end())
   {

--- a/rychkov.mihail/F0/main_processor_init.cpp
+++ b/rychkov.mihail/F0/main_processor_init.cpp
@@ -1,0 +1,147 @@
+#include "main_processor.hpp"
+
+#include <fstream>
+#include <cstring>
+#include <utility>
+#include <stdexcept>
+#include <algorithm>
+
+using namespace std::literals::string_literals;
+
+bool rychkov::MainProcessor::init(ParserContext& context, int argc, char** argv)
+{
+  bool sources = false;
+  bool out = false;
+  std::vector< std::string > files;
+  for (int i = 1; i < argc; i++)
+  {
+    if (std::strcmp(argv[i], "--help") == 0)
+    {
+      help(context.out);
+      return false;
+    }
+    if (std::strcmp(argv[i], "-c") == 0)
+    {
+      sources = true;
+    }
+    else if (std::strcmp(argv[i], "--load") == 0)
+    {
+      sources = false;
+      if (++i >= argc)
+      {
+        throw std::invalid_argument("missing save-file name");
+      }
+      if (!load(context.out, context.err, argv[i]))
+      {
+        throw std::runtime_error("failed to load save-file \""s + argv[i] + '"');
+      }
+    }
+    else if (std::strcmp(argv[i], "-E") == 0)
+    {
+      if (last_stage_ != CPARSER)
+      {
+        throw std::invalid_argument("stop flag cannot be specified more then once");
+      }
+      last_stage_ = PREPROCESSOR;
+      sources = false;
+    }
+    else if (std::strcmp(argv[i], "-L") == 0)
+    {
+      if (last_stage_ != CPARSER)
+      {
+        throw std::invalid_argument("stop flag cannot be specified more then once");
+      }
+      last_stage_ = LEXER;
+      sources = false;
+    }
+    else if (std::strcmp(argv[i], "-o") == 0)
+    {
+      sources = false;
+      if (out)
+      {
+        throw std::invalid_argument("out flag duplicates");
+      }
+      out = true;
+    }
+    else if (std::strcmp(argv[i], "-I") == 0)
+    {
+      sources = false;
+      if (++i >= argc)
+      {
+        throw std::invalid_argument("missing include directory");
+      }
+      include_dirs_.push_back(argv[i]);
+    }
+    else
+    {
+      if (!sources)
+      {
+        throw std::invalid_argument("unknown command: \""s + argv[i] + '"');
+      }
+      files.push_back(argv[i]);
+    }
+  }
+
+  std::sort(files.begin(), files.end());
+  files.erase(std::unique(files.begin(), files.end()), files.end());
+
+  std::string ext = (last_stage_ == PREPROCESSOR ? ".i" : (last_stage_ == LEXER ? ".lex" : ".json"));
+  for (const std::string& filename: files)
+  {
+    std::ostream* output = &context.out;
+    std::ofstream ostream;
+    std::string output_filename;
+    if (out)
+    {
+      std::string::size_type ext_p = filename.rfind(".c");
+      if (ext_p == std::string::npos)
+      {
+        output_filename = filename + ext;
+      }
+      else
+      {
+        output_filename = filename;
+        output_filename.replace(ext_p, 2, ext);
+      }
+      ostream.open(output_filename);
+      if (!ostream)
+      {
+        throw std::runtime_error("failed to open output file: \"" + output_filename + '"');
+      }
+      output = &ostream;
+    }
+    CParseContext parse_context{*output, context.err, filename};
+    context.out << "<--PARSE: \"" << filename << "\"-->\n";
+    if (!parse(parse_context, true))
+    {
+      throw std::runtime_error("failed to parse file \"" + filename + "\" - stopping");
+    }
+    if (out && (last_stage_ == CPARSER))
+    {
+      save(context.err, output_filename);
+      parsed_.clear();
+    }
+  }
+  context.out << "<--DONE-->\n";
+  return !out;
+}
+
+bool rychkov::MainProcessor::parse(CParseContext file_context, bool overwrite)
+{
+  if (overwrite)
+  {
+    parsed_.erase(file_context.file);
+  }
+  std::pair< decltype(parsed_)::iterator, bool > cell = parsed_.emplace(file_context.file,
+    ParseCell{file_context, last_stage_, include_dirs_});
+  if (!cell.second)
+  {
+    return true;
+  }
+  std::ifstream in(cell.first->first);
+  if (!in)
+  {
+    throw std::invalid_argument("failed to open source file: \"" + file_context.file + '"');
+  }
+  return cell.first->second.parse(in);
+}

--- a/rychkov.mihail/F0/main_processor_init.cpp
+++ b/rychkov.mihail/F0/main_processor_init.cpp
@@ -5,6 +5,7 @@
 #include <utility>
 #include <stdexcept>
 #include <algorithm>
+#include <algorithm.hpp>
 
 using namespace std::literals::string_literals;
 
@@ -83,7 +84,7 @@ bool rychkov::MainProcessor::init(ParserContext& context, int argc, char** argv)
   }
 
   std::sort(files.begin(), files.end());
-  files.erase(std::unique(files.begin(), files.end()), files.end());
+  files.erase(rychkov::unique(files.begin(), files.end()), files.end());
 
   std::string ext = (last_stage_ == PREPROCESSOR ? ".i" : (last_stage_ == LEXER ? ".lex" : ".json"));
   for (const std::string& filename: files)

--- a/rychkov.mihail/F0/main_processor_load.cpp
+++ b/rychkov.mihail/F0/main_processor_load.cpp
@@ -1,0 +1,412 @@
+#include "main_processor.hpp"
+
+#include <iostream>
+#include <fstream>
+#include <sstream>
+#include <iterator>
+#include <utility>
+#include <stdexcept>
+#include <boost/json.hpp>
+
+namespace rychkov
+{
+  struct Loader
+  {
+    CParser& parser;
+    Preprocessor preproc{std::unique_ptr< Lexer >{new Lexer{std::unique_ptr< CParser >{new CParser}}}, {}};
+    size_t depth = 1;
+
+    static Macro as_macro(const boost::json::value& val);
+    void clear_scope();
+
+    void operator()(const boost::json::value& val);
+    entities::Variable as_var_data(const boost::json::string& str);
+    entities::Expression as_expr(const boost::json::value& val);
+    entities::Expression::operand as_operand(const boost::json::value& val);
+    entities::Literal as_lit(const boost::json::value& val);
+    entities::Variable as_var(const boost::json::value& val);
+    entities::Function as_func(const boost::json::value& val);
+    entities::Struct as_struct(const boost::json::value& val);
+    entities::Enum as_enum(const boost::json::value& val);
+    entities::Union as_union(const boost::json::value& val);
+    entities::Alias as_alias(const boost::json::value& val);
+    entities::Statement as_statement(const boost::json::value& val);
+    entities::Declaration as_decl(const boost::json::value& val);
+    entities::Declaration::declared as_declared(const boost::json::value& val);
+    entities::CastOperation as_cast(const boost::json::value& val);
+    entities::Body as_body(const boost::json::value& val);
+  };
+}
+
+bool rychkov::MainProcessor::load(std::ostream& out, std::ostream& err, std::string filename)
+{
+  std::ifstream in(filename);
+  if (!in)
+  {
+    err << "failed to open save file on read - \"" << filename << "\"\n";
+    return false;
+  }
+  boost::json::value doc = boost::json::parse(in);
+  std::map< std::string, ParseCell > new_parsed;
+  size_t ngenerated = 0;
+  for (const boost::json::object::value_type& file: doc.as_object())
+  {
+    std::pair< decltype(new_parsed)::iterator, bool > cell_p = new_parsed.emplace(file.key(),
+          ParseCell{{out, err, file.key()}, last_stage_, include_dirs_});
+    if (cell_p.second)
+    {
+      Preprocessor& preproc = cell_p.first->second.preproc;
+      out << "<--LOAD: \"" << file.key() << "\"-->\n";
+      const boost::json::object& obj = file.value().as_object();
+
+      const boost::json::array& macros = obj.at("macros").as_array();
+      std::transform(macros.begin(), macros.end(),
+            std::inserter(preproc.macros, preproc.macros.end()), Loader::as_macro);
+      const boost::json::array& legacy = obj.at("old_macro").as_array();
+      std::transform(legacy.begin(), legacy.end(),
+            std::inserter(preproc.legacy_macros, preproc.legacy_macros.end()), Loader::as_macro);
+
+      const boost::json::array& pgm = obj.at("pgm").as_array();
+      CParser& parser = *preproc.next->next;
+      Loader loader = std::for_each(pgm.begin(), pgm.end(), Loader{parser});
+      cell_p.first->second.real_file = obj.at("real").as_bool();
+      ngenerated += !cell_p.first->second.real_file;
+      cell_p.first->second.cache = boost::json::value_to< std::string >(obj.at("cache"));
+
+      parser.defined_functions = loader.preproc.next->next->defined_functions;
+      parser.base_types = loader.preproc.next->next->base_types;
+      parser.variables = loader.preproc.next->next->variables;
+      parser.structs = loader.preproc.next->next->structs;
+      parser.unions = loader.preproc.next->next->unions;
+      parser.enums = loader.preproc.next->next->enums;
+      parser.aliases = loader.preproc.next->next->aliases;
+      parser.defined_functions = loader.preproc.next->next->defined_functions;
+    }
+  }
+  parsed_ = std::move(new_parsed);
+  generated_files = ngenerated;
+  return true;
+}
+rychkov::Macro rychkov::Loader::as_macro(const boost::json::value& val)
+{
+  const boost::json::object& obj = val.as_object();
+  rychkov::Macro result{boost::json::value_to< std::string >(obj.at("name")),
+        boost::json::value_to< std::string >(obj.at("body")), obj.at("fstyle").as_bool()};
+  const boost::json::array& params = obj.at("params").as_array();
+  result.parameters.reserve(params.size());
+  std::transform(params.begin(), params.end(), std::back_inserter(result.parameters),
+        boost::json::value_to< std::string >);
+  return result;
+}
+void rychkov::Loader::clear_scope()
+{
+  CParser::clear_scope(preproc.next->next->base_types, depth);
+  CParser::clear_scope(preproc.next->next->variables, depth);
+  CParser::clear_scope(preproc.next->next->structs, depth);
+  CParser::clear_scope(preproc.next->next->unions, depth);
+  CParser::clear_scope(preproc.next->next->enums, depth);
+}
+void rychkov::Loader::operator()(const boost::json::value& val)
+{
+  parser.push_back(as_expr(val));
+}
+
+rychkov::entities::Expression rychkov::Loader::as_expr(const boost::json::value& val)
+{
+  if (val.is_array())
+  {
+    return as_body(val);
+  }
+  const boost::json::object& obj = val.as_object();
+  if (obj.empty())
+  {
+    return {};
+  }
+  if (obj.at("obj") == "expr")
+  {
+    Operator::Type type = static_cast< Operator::Type >(obj.at("size").as_int64());
+    if ((type != Operator::MULTIPLE) && ((type > 3) || (type == 0)))
+    {
+      throw std::invalid_argument{"wrong operator size"};
+    }
+    Operator oper{type};
+    oper.token = boost::json::value_to< std::string >(obj.at("token"));
+    oper.right_align = obj.at("rallign").as_bool();
+    decltype(Lexer::cases)::const_iterator cases = Lexer::cases.find(oper.token);
+    bool found = false;
+    entities::Expression result;
+    if (cases != Lexer::cases.end())
+    {
+      for (const Operator& i: *cases)
+      {
+        if ((i.right_align == oper.right_align) && (i.type == oper.type))
+        {
+          result.operation = &i;
+          found = true;
+        }
+      }
+    }
+    else
+    {
+      found = true;
+      if (oper.token == CParser::parentheses.token)
+      {
+        result.operation = &CParser::parentheses;
+      }
+      else if (oper.token == CParser::brackets.token)
+      {
+        result.operation = &CParser::brackets;
+      }
+      else if (oper.token == CParser::comma.token)
+      {
+        result.operation = &CParser::comma;
+      }
+      else if (oper.token == CParser::inline_if.token)
+      {
+        result.operation = &CParser::inline_if;
+      }
+      else
+      {
+        found = false;
+      }
+    }
+    if (!found)
+    {
+      throw std::invalid_argument{"unknown operator"};
+    }
+    result.result_type = as_var_data(obj.at("res_t").as_string()).type;
+    const boost::json::array& operands = obj.at("operands").as_array();
+    result.operands.reserve(operands.size());
+    for (const boost::json::value& operand: operands)
+    {
+      result.operands.push_back(as_expr(operand));
+    }
+    return result;
+  }
+  return {nullptr, {as_operand(val)}};
+}
+rychkov::entities::Expression::operand rychkov::Loader::as_operand(const boost::json::value& val)
+{
+  if (val.is_array())
+  {
+    return as_body(val);
+  }
+  const boost::json::object& obj = val.as_object();
+  const boost::json::string& type = obj.at("obj").as_string();
+  if (type == "expr")
+  {
+    return as_expr(val);
+  }
+  else if (type == "var")
+  {
+    return as_var(val);
+  }
+  else if (type == "lit")
+  {
+    return as_lit(val);
+  }
+  else if (type == "decl")
+  {
+    return as_decl(val);
+  }
+  else if (type == "cast")
+  {
+    return as_cast(val);
+  }
+  throw std::invalid_argument{"unknown expression operand"};
+}
+rychkov::entities::Variable rychkov::Loader::as_var_data(const boost::json::string& str)
+{
+  std::stringstream temp{std::string{str.begin(), str.end()}};
+  std::stringstream err;
+  CParseContext context{temp, err, "json-load"};
+  preproc.parse(context, temp);
+  const TypeParser& type_parser = preproc.next->next->next();
+  if (!type_parser.ready())
+  {
+    throw std::invalid_argument{"incorrect variable"};
+  }
+  if (context.nerrors > 0)
+  {
+    throw std::runtime_error{err.str()};
+  }
+  preproc.next->next->prepare_type();
+  entities::Variable result = type_parser.variable();
+  preproc.next->next->clear_program();
+  return result;
+}
+rychkov::entities::Variable rychkov::Loader::as_var(const boost::json::value& val)
+{
+  return as_var_data(val.at("data").as_string());
+}
+rychkov::entities::Function rychkov::Loader::as_func(const boost::json::value& val)
+{
+  const boost::json::object& obj = val.as_object();
+  entities::Variable temp = as_var(obj.at("sign"));
+  entities::Function result{std::move(temp.type), std::move(temp.name)};
+  const boost::json::array& params = obj.at("parameters").as_array();
+  result.parameters.reserve(params.size());
+  std::transform(params.begin(), params.end(), std::back_inserter(result.parameters),
+        static_cast< std::string(*)(const boost::json::value&) >(boost::json::value_to< std::string >));
+  return result;
+}
+rychkov::entities::Struct rychkov::Loader::as_struct(const boost::json::value& val)
+{
+  const boost::json::object& obj = val.as_object();
+  entities::Struct result{boost::json::value_to< std::string >(obj.at("name"))};
+  preproc.next->next->base_types.insert({{result.name, typing::STRUCT}, depth});
+  const boost::json::array& fields = obj.at("fields").as_array();
+  ++depth;
+  for (const boost::json::value& field: fields)
+  {
+    result.fields.insert(as_var(field));
+  }
+  --depth;
+  clear_scope();
+  preproc.next->next->structs.emplace(result, depth);
+  return result;
+}
+rychkov::entities::Enum rychkov::Loader::as_enum(const boost::json::value& val)
+{
+  const boost::json::object& obj = val.as_object();
+  entities::Enum result{boost::json::value_to< std::string >(obj.at("name"))};
+  preproc.next->next->base_types.insert({{result.name, typing::ENUM}, depth});
+  const boost::json::array& fields = obj.at("fields").as_array();
+  for (const boost::json::value& field: fields)
+  {
+    result.fields.emplace(boost::json::value_to< std::string >(field.as_array()[0]),
+          field.as_array()[1].as_int64());
+  }
+  preproc.next->next->enums.emplace(result, depth);
+  return result;
+}
+rychkov::entities::Union rychkov::Loader::as_union(const boost::json::value& val)
+{
+  const boost::json::object& obj = val.as_object();
+  entities::Union result{boost::json::value_to< std::string >(obj.at("name"))};
+  preproc.next->next->base_types.insert({{result.name, typing::STRUCT}, depth});
+  const boost::json::array& fields = obj.at("fields").as_array();
+  ++depth;
+  for (const boost::json::value& field: fields)
+  {
+    result.fields.insert(as_var(field));
+  }
+  --depth;
+  clear_scope();
+  preproc.next->next->unions.emplace(result, depth);
+  return result;
+}
+rychkov::entities::Alias rychkov::Loader::as_alias(const boost::json::value& val)
+{
+  entities::Variable result = as_var(val.at("sign"));
+  return {std::move(result.type), std::move(result.name)};
+}
+rychkov::entities::Statement rychkov::Loader::as_statement(const boost::json::value& val)
+{
+  const boost::json::object& obj = val.as_object();
+  entities::Statement result{static_cast< entities::Statement::Type >(obj.at("type").as_int64())};
+  if (result.type >= entities::Statement::TYPE_LAST)
+  {
+    throw std::invalid_argument{"wrong statement type"};
+  }
+  const boost::json::array& conditions = obj.at("conditions").as_array();
+  result.conditions.reserve(conditions.size());
+  ++depth;
+  for (const boost::json::value& expr: conditions)
+  {
+    result.conditions.push_back(as_expr(expr));
+  }
+  --depth;
+  clear_scope();
+  return result;
+}
+rychkov::entities::Literal rychkov::Loader::as_lit(const boost::json::value& val)
+{
+  const boost::json::object& obj = val.as_object();
+  entities::Literal::Type type = static_cast< entities::Literal::Type >(obj.at("type").as_int64());
+  if (type >= 3)
+  {
+    throw std::invalid_argument{"wrong literal type"};
+  }
+  return {boost::json::value_to< std::string >(obj.at("body")),
+        boost::json::value_to< std::string >(obj.at("suf")), type,
+        as_var_data(obj.at("res_type").as_string()).type};
+}
+rychkov::entities::Declaration rychkov::Loader::as_decl(const boost::json::value& val)
+{
+  const boost::json::object& obj = val.as_object();
+  entities::ScopeType scope = static_cast< entities::ScopeType >(obj.at("scope").as_int64());
+  if (scope >= 3)
+  {
+    throw std::invalid_argument{"wrong scope type"};
+  }
+  rychkov::entities::Declaration result{as_declared(obj.at("data")), nullptr, scope};
+  if (obj.at("value").is_null())
+  {
+    return result;
+  }
+  ++depth;
+  result.value = as_expr(obj.at("value"));
+  --depth;
+  clear_scope();
+  return result;
+}
+rychkov::entities::Declaration::declared rychkov::Loader::as_declared(const boost::json::value& val)
+{
+  const boost::json::object& obj = val.as_object();
+  const boost::json::string& type = obj.at("obj").as_string();
+  if (type == "var")
+  {
+    entities::Variable result = as_var(val);
+    parser.variables.emplace(result, depth);
+    return result;
+  }
+  else if (type == "func")
+  {
+    entities::Function result = as_func(val);
+    parser.variables.insert({{result.type, result.name}, depth});
+    return result;
+  }
+  else if (type == "struct")
+  {
+    return as_struct(val);
+  }
+  else if (type == "enum")
+  {
+    return as_enum(val);
+  }
+  else if (type == "union")
+  {
+    return as_union(val);
+  }
+  else if (type == "alias")
+  {
+    entities::Alias result = as_alias(val);
+    parser.aliases.emplace(result);
+    return result;
+  }
+  else if (type == "stmtnt")
+  {
+    return as_statement(val);
+  }
+  throw std::invalid_argument{"unknown declared"};
+}
+rychkov::entities::CastOperation rychkov::Loader::as_cast(const boost::json::value& val)
+{
+  const boost::json::object& obj = val.as_object();
+  return {as_var_data(obj.at("to").as_string()).type, obj.at("explicit").as_bool(), as_expr(obj.at("value"))};
+}
+rychkov::entities::Body rychkov::Loader::as_body(const boost::json::value& val)
+{
+  const boost::json::array& data = val.as_array();
+  entities::Body result;
+  result.data.reserve(data.size());
+  ++depth;
+  for (const boost::json::value& expr: data)
+  {
+    result.data.push_back(as_expr(expr));
+  }
+  --depth;
+  clear_scope();
+  return result;
+}

--- a/rychkov.mihail/F0/main_processor_load.cpp
+++ b/rychkov.mihail/F0/main_processor_load.cpp
@@ -47,7 +47,7 @@ bool rychkov::MainProcessor::load(std::ostream& out, std::ostream& err, std::str
     return false;
   }
   boost::json::value doc = boost::json::parse(in);
-  std::map< std::string, ParseCell > new_parsed;
+  Map< std::string, ParseCell > new_parsed;
   size_t ngenerated = 0;
   for (const boost::json::object::value_type& file: doc.as_object())
   {

--- a/rychkov.mihail/F0/main_processor_save.cpp
+++ b/rychkov.mihail/F0/main_processor_save.cpp
@@ -1,0 +1,158 @@
+#include "main_processor.hpp"
+
+#include <fstream>
+#include <sstream>
+#include <algorithm>
+#include <iterator>
+#include <boost/json.hpp>
+#include "print_content.hpp"
+
+namespace rychkov
+{
+  struct Serializer
+  {
+    std::string operator()(const typing::Type& type);
+    boost::json::value operator()(const Macro& macro);
+    boost::json::value operator()(const entities::Variable& var);
+    boost::json::value operator()(const entities::Function& func);
+    boost::json::value operator()(const entities::Body& body);
+    boost::json::value operator()(const entities::Statement& statement);
+    boost::json::value operator()(const entities::Struct& structure);
+    boost::json::value operator()(const entities::Enum& structure);
+    boost::json::value operator()(const entities::Union& structure);
+    boost::json::value operator()(const entities::Alias& alias);
+    boost::json::value operator()(const entities::Declaration& decl);
+
+    boost::json::value operator()(const entities::Literal& literal);
+    boost::json::value operator()(const entities::CastOperation& cast);
+
+    boost::json::value operator()(const DynMemWrapper< entities::Expression >& root);
+    boost::json::value operator()(const entities::Expression& root);
+    boost::json::value operator()(const entities::Expression::operand& operand);
+  };
+}
+
+bool rychkov::MainProcessor::save(std::ostream& err, std::string filename) const
+{
+  std::ofstream out(filename);
+  if (!out)
+  {
+    err << "failed to open save file on write - \"" << filename << "\"\n";
+    return false;
+  }
+  boost::json::object doc;
+  for (const std::pair< const std::string, ParseCell >& file: parsed_)
+  {
+    const Preprocessor& preproc = file.second.preproc;
+    const CParser& src = *preproc.next->next;
+    Serializer serial;
+    boost::json::array macros(preproc.macros.size());
+    boost::json::array legacy_macros(preproc.legacy_macros.size());
+    boost::json::array program;
+    std::transform(preproc.macros.begin(), preproc.macros.end(), macros.begin(), serial);
+    std::transform(preproc.legacy_macros.begin(), preproc.legacy_macros.end(), legacy_macros.begin(), serial);
+    std::transform(src.begin(), src.end(), std::back_inserter(program), serial);
+    doc[file.first] = boost::json::object{{"macros", std::move(macros)},
+          {"old_macro", std::move(legacy_macros)}, {"pgm", std::move(program)},
+          {"real", file.second.real_file}, {"cache", file.second.cache}};
+  }
+  out << doc << '\n';
+  return out.good();
+}
+
+std::string rychkov::Serializer::operator()(const typing::Type& type)
+{
+  std::ostringstream temp;
+  temp << type;
+  return temp.str();
+}
+boost::json::value rychkov::Serializer::operator()(const Macro& macro)
+{
+  return boost::json::object{{"name", macro.name}, {"fstyle", macro.func_style}, {"body", macro.body},
+        {"params", boost::json::array(macro.parameters.begin(), macro.parameters.end())}};
+}
+boost::json::value rychkov::Serializer::operator()(const entities::Variable& var)
+{
+  std::ostringstream temp;
+  temp << var;
+  return boost::json::object{{"obj", "var"}, {"data", temp.str()}};
+}
+boost::json::value rychkov::Serializer::operator()(const entities::Function& func)
+{
+  boost::json::array parameters(func.parameters.size());
+  std::copy(func.parameters.begin(), func.parameters.end(), parameters.begin());
+  return boost::json::object{{"obj", "func"}, {"parameters", std::move(parameters)},
+        {"sign", operator()(entities::Variable{func.type, func.name})}};
+}
+boost::json::value rychkov::Serializer::operator()(const entities::Body& body)
+{
+  boost::json::array result(body.data.size());
+  std::transform(body.data.begin(), body.data.end(), result.begin(), *this);
+  return result;
+}
+boost::json::value rychkov::Serializer::operator()(const entities::Statement& statement)
+{
+  boost::json::array conditions(statement.conditions.size());
+  std::transform(statement.conditions.begin(), statement.conditions.end(), conditions.begin(), *this);
+  return boost::json::object{{"obj", "stmtnt"}, {"type", statement.type}, {"conditions", std::move(conditions)}};
+}
+boost::json::value rychkov::Serializer::operator()(const entities::Struct& structure)
+{
+  boost::json::array fields(structure.fields.size());
+  std::transform(structure.fields.begin(), structure.fields.end(), fields.begin(), *this);
+  return boost::json::object{{"obj", "struct"}, {"name", structure.name}, {"fields", std::move(fields)}};
+}
+boost::json::value rychkov::Serializer::operator()(const entities::Enum& structure)
+{
+  return boost::json::object{{"obj", "enum"}, {"name", structure.name},
+        {"fields", boost::json::object(structure.fields.begin(), structure.fields.end())}};
+}
+boost::json::value rychkov::Serializer::operator()(const entities::Union& structure)
+{
+  boost::json::array fields(structure.fields.size());
+  std::transform(structure.fields.begin(), structure.fields.end(), fields.begin(), *this);
+  return boost::json::object{{"obj", "union"}, {"name", structure.name}, {"fields", std::move(fields)}};
+}
+boost::json::value rychkov::Serializer::operator()(const entities::Alias& alias)
+{
+  return boost::json::object{{"obj", "alias"}, {"sign", operator()(entities::Variable{alias.type, alias.name})}};
+}
+boost::json::value rychkov::Serializer::operator()(const entities::Declaration& decl)
+{
+  return boost::json::object{{"obj", "decl"}, {"data", boost::variant2::visit(*this, decl.data)},
+        {"value", operator()(decl.value)}, {"scope", decl.scope}};
+}
+boost::json::value rychkov::Serializer::operator()(const entities::Literal& lit)
+{
+  return boost::json::object{{"obj", "lit"}, {"body", lit.literal}, {"suf", lit.suffix},
+        {"type", lit.type}, {"res_type", operator()(lit.result_type)}};
+}
+boost::json::value rychkov::Serializer::operator()(const entities::CastOperation& cast)
+{
+  return boost::json::object{{"obj", "cast"}, {"to", operator()(cast.to)}, {"explicit", cast.is_explicit},
+        {"value", operator()(cast.expr)}};
+}
+boost::json::value rychkov::Serializer::operator()(const entities::Expression& expr)
+{
+  if (expr.empty())
+  {
+    return boost::json::object{};
+  }
+  if (entities::is_bridge(expr))
+  {
+    return operator()(expr.operands[0]);
+  }
+  boost::json::array operands(expr.operands.size());
+  std::transform(expr.operands.begin(), expr.operands.end(), operands.begin(), *this);
+  return boost::json::object{{"obj", "expr"}, {"token", expr.operation->token},
+        {"rallign", expr.operation->right_align}, {"size", expr.operation->type},
+        {"operands", std::move(operands)}, {"res_t", operator()(expr.result_type)}};
+}
+boost::json::value rychkov::Serializer::operator()(const DynMemWrapper< entities::Expression >& ptr)
+{
+  return ptr != nullptr ? operator()(*ptr) : boost::json::value{};
+}
+boost::json::value rychkov::Serializer::operator()(const entities::Expression::operand& root)
+{
+  return boost::variant2::visit(*this, root);
+}

--- a/rychkov.mihail/F0/main_processor_save.cpp
+++ b/rychkov.mihail/F0/main_processor_save.cpp
@@ -2,9 +2,9 @@
 
 #include <fstream>
 #include <sstream>
-#include <algorithm>
 #include <iterator>
 #include <boost/json.hpp>
+#include <algorithm.hpp>
 #include "print_content.hpp"
 
 namespace rychkov
@@ -49,9 +49,9 @@ bool rychkov::MainProcessor::save(std::ostream& err, std::string filename) const
     boost::json::array macros(preproc.macros.size());
     boost::json::array legacy_macros(preproc.legacy_macros.size());
     boost::json::array program;
-    std::transform(preproc.macros.begin(), preproc.macros.end(), macros.begin(), serial);
-    std::transform(preproc.legacy_macros.begin(), preproc.legacy_macros.end(), legacy_macros.begin(), serial);
-    std::transform(src.begin(), src.end(), std::back_inserter(program), serial);
+    rychkov::transform(preproc.macros.begin(), preproc.macros.end(), macros.begin(), serial);
+    rychkov::transform(preproc.legacy_macros.begin(), preproc.legacy_macros.end(), legacy_macros.begin(), serial);
+    rychkov::transform(src.begin(), src.end(), std::back_inserter(program), serial);
     doc[file.first] = boost::json::object{{"macros", std::move(macros)},
           {"old_macro", std::move(legacy_macros)}, {"pgm", std::move(program)},
           {"real", file.second.real_file}, {"cache", file.second.cache}};
@@ -80,26 +80,26 @@ boost::json::value rychkov::Serializer::operator()(const entities::Variable& var
 boost::json::value rychkov::Serializer::operator()(const entities::Function& func)
 {
   boost::json::array parameters(func.parameters.size());
-  std::copy(func.parameters.begin(), func.parameters.end(), parameters.begin());
+  rychkov::copy(func.parameters.begin(), func.parameters.end(), parameters.begin());
   return boost::json::object{{"obj", "func"}, {"parameters", std::move(parameters)},
         {"sign", operator()(entities::Variable{func.type, func.name})}};
 }
 boost::json::value rychkov::Serializer::operator()(const entities::Body& body)
 {
   boost::json::array result(body.data.size());
-  std::transform(body.data.begin(), body.data.end(), result.begin(), *this);
+  rychkov::transform(body.data.begin(), body.data.end(), result.begin(), *this);
   return result;
 }
 boost::json::value rychkov::Serializer::operator()(const entities::Statement& statement)
 {
   boost::json::array conditions(statement.conditions.size());
-  std::transform(statement.conditions.begin(), statement.conditions.end(), conditions.begin(), *this);
+  rychkov::transform(statement.conditions.begin(), statement.conditions.end(), conditions.begin(), *this);
   return boost::json::object{{"obj", "stmtnt"}, {"type", statement.type}, {"conditions", std::move(conditions)}};
 }
 boost::json::value rychkov::Serializer::operator()(const entities::Struct& structure)
 {
   boost::json::array fields(structure.fields.size());
-  std::transform(structure.fields.begin(), structure.fields.end(), fields.begin(), *this);
+  rychkov::transform(structure.fields.begin(), structure.fields.end(), fields.begin(), *this);
   return boost::json::object{{"obj", "struct"}, {"name", structure.name}, {"fields", std::move(fields)}};
 }
 boost::json::value rychkov::Serializer::operator()(const entities::Enum& structure)
@@ -110,7 +110,7 @@ boost::json::value rychkov::Serializer::operator()(const entities::Enum& structu
 boost::json::value rychkov::Serializer::operator()(const entities::Union& structure)
 {
   boost::json::array fields(structure.fields.size());
-  std::transform(structure.fields.begin(), structure.fields.end(), fields.begin(), *this);
+  rychkov::transform(structure.fields.begin(), structure.fields.end(), fields.begin(), *this);
   return boost::json::object{{"obj", "union"}, {"name", structure.name}, {"fields", std::move(fields)}};
 }
 boost::json::value rychkov::Serializer::operator()(const entities::Alias& alias)
@@ -143,7 +143,7 @@ boost::json::value rychkov::Serializer::operator()(const entities::Expression& e
     return operator()(expr.operands[0]);
   }
   boost::json::array operands(expr.operands.size());
-  std::transform(expr.operands.begin(), expr.operands.end(), operands.begin(), *this);
+  rychkov::transform(expr.operands.begin(), expr.operands.end(), operands.begin(), *this);
   return boost::json::object{{"obj", "expr"}, {"token", expr.operation->token},
         {"rallign", expr.operation->right_align}, {"size", expr.operation->type},
         {"operands", std::move(operands)}, {"res_t", operator()(expr.result_type)}};

--- a/rychkov.mihail/F0/main_processor_save.cpp
+++ b/rychkov.mihail/F0/main_processor_save.cpp
@@ -119,7 +119,7 @@ boost::json::value rychkov::Serializer::operator()(const entities::Alias& alias)
 }
 boost::json::value rychkov::Serializer::operator()(const entities::Declaration& decl)
 {
-  return boost::json::object{{"obj", "decl"}, {"data", boost::variant2::visit(*this, decl.data)},
+  return boost::json::object{{"obj", "decl"}, {"data", visit(*this, decl.data)},
         {"value", operator()(decl.value)}, {"scope", decl.scope}};
 }
 boost::json::value rychkov::Serializer::operator()(const entities::Literal& lit)
@@ -154,5 +154,5 @@ boost::json::value rychkov::Serializer::operator()(const DynMemWrapper< entities
 }
 boost::json::value rychkov::Serializer::operator()(const entities::Expression::operand& root)
 {
-  return boost::variant2::visit(*this, root);
+  return visit(*this, root);
 }

--- a/rychkov.mihail/F0/parse_braces.cpp
+++ b/rychkov.mihail/F0/parse_braces.cpp
@@ -1,0 +1,144 @@
+#include "cparser.hpp"
+
+#include <iostream>
+#include "print_content.hpp"
+
+void rychkov::CParser::parse_open_brace(CParseContext& context)
+{
+  if (global_scope())
+  {
+    log(context, "braced-enclosed body cannot be declared alone in global scope");
+    return;
+  }
+  if (entities::is_decl(*stack_.top()))
+  {
+    entities::Declaration& decl = boost::variant2::get< entities::Declaration >(stack_.top()->operands[0]);
+    if (boost::variant2::holds_alternative< entities::Struct >(decl.data))
+    {
+      entities::Struct& data = boost::variant2::get< entities::Struct >(decl.data);
+      if (data.name.empty())
+      {
+        log(context, "struct must have name");
+        return;
+      }
+    }
+    else if (boost::variant2::holds_alternative< entities::Function >(decl.data))
+    {
+      entities::Function& data = boost::variant2::get< entities::Function >(decl.data);
+      for (size_t i = 0; i < data.parameters.size(); i++)
+      {
+        if (!data.parameters[i].empty())
+        {
+          variables.insert({{data.type.function_parameters[i], data.parameters[i]}, stack_.size() + 1});
+        }
+      }
+      if (find_overload(data.name, data.type.function_parameters).first != nullptr)
+      {
+        start_log(context) << "cannot define same function again - " << data;
+        finish_log(context);
+      }
+      else
+      {
+        defined_functions.insert({data.type, data.name});
+      }
+    }
+    else
+    {
+      log(context, "braced enclosed body cannot follow this declaration");
+      return;
+    }
+    decl.value = entities::Body{};
+    stack_.push(&*decl.value);
+    entities::Body& body = boost::variant2::get< entities::Body >(stack_.top()->operands[0]);
+    stack_.push(&body.data[0]);
+    return;
+  }
+  if (stack_.top()->empty())
+  {
+    stack_.top()->operands.emplace_back(entities::Body{});
+    entities::Body& body = boost::variant2::get< entities::Body >(stack_.top()->operands[0]);
+    stack_.push(&body.data[0]);
+    return;
+  }
+  log(context, "unexpected braced-enclosed body");
+}
+void rychkov::CParser::parse_close_brace(CParseContext& context)
+{
+  if (stack_.size() == 1)
+  {
+    log(context, "unpaired closing brace");
+    return;
+  }
+  if (stack_.top()->empty())
+  {
+    stack_.pop();
+  }
+  if (entities::is_body(*stack_.top()))
+  {
+    entities::Body& body = boost::variant2::get< entities::Body >(stack_.top()->operands[0]);
+    body.data.pop_back();
+    stack_.pop();
+    clear_scope();
+    if (entities::is_decl(*stack_.top()))
+    {
+      entities::Declaration& decl = boost::variant2::get< entities::Declaration >(stack_.top()->operands[0]);
+      if (boost::variant2::holds_alternative< entities::Struct >(decl.data))
+      {
+        entities::Struct& structure = boost::variant2::get< entities::Struct >(decl.data);
+        for (const entities::Expression& i: body.data)
+        {
+          if (entities::is_decl(i))
+          {
+            const entities::Declaration& var_decl = boost::variant2::get< entities::Declaration >(i.operands[0]);
+            if (!boost::variant2::holds_alternative< entities::Variable >(var_decl.data))
+            {
+              log(context, "struct body must consist only of variable declarations");
+              continue;
+            }
+            if (var_decl.value != nullptr)
+            {
+              log(context, "struct fields cannot have default values");
+              continue;
+            }
+            const entities::Variable& var = boost::variant2::get< entities::Variable >(var_decl.data);
+            if (structure.fields.find(var.name) == structure.fields.end())
+            {
+              structure.fields.insert(var);
+              continue;
+            }
+            log(context, "struct fields name duplicates");
+            continue;
+          }
+          else if (!i.empty())
+          {
+            log(context, "struct body must consist only of variable declarations");
+          }
+        }
+      }
+      if (boost::variant2::holds_alternative< entities::Function >(decl.data))
+      {
+        program_.emplace_back();
+        stack_.top() = &program_.back();
+      }
+      if (boost::variant2::holds_alternative< entities::Statement >(decl.data))
+      {
+        entities::Statement& statement = boost::variant2::get< entities::Statement >(decl.data);
+        if ((statement.type == entities::Statement::IF) || (statement.type == entities::Statement::WHILE))
+        {
+          stack_.pop();
+          append_empty(context);
+          clear_scope();
+          return;
+        }
+      }
+    }
+    else if (entities::is_body(*stack_.top()))
+    {
+      entities::Body& body = boost::variant2::get< entities::Body >(stack_.top()->operands[0]);
+      body.data.emplace_back();
+      stack_.push(&body.data.back());
+    }
+    return;
+  }
+  log(context, "unpaired closing brace");
+}

--- a/rychkov.mihail/F0/parse_braces.cpp
+++ b/rychkov.mihail/F0/parse_braces.cpp
@@ -12,19 +12,19 @@ void rychkov::CParser::parse_open_brace(CParseContext& context)
   }
   if (entities::is_decl(*stack_.top()))
   {
-    entities::Declaration& decl = boost::variant2::get< entities::Declaration >(stack_.top()->operands[0]);
-    if (boost::variant2::holds_alternative< entities::Struct >(decl.data))
+    entities::Declaration& decl = get< entities::Declaration >(stack_.top()->operands[0]);
+    if (holds_alternative< entities::Struct >(decl.data))
     {
-      entities::Struct& data = boost::variant2::get< entities::Struct >(decl.data);
+      entities::Struct& data = get< entities::Struct >(decl.data);
       if (data.name.empty())
       {
         log(context, "struct must have name");
         return;
       }
     }
-    else if (boost::variant2::holds_alternative< entities::Function >(decl.data))
+    else if (holds_alternative< entities::Function >(decl.data))
     {
-      entities::Function& data = boost::variant2::get< entities::Function >(decl.data);
+      entities::Function& data = get< entities::Function >(decl.data);
       for (size_t i = 0; i < data.parameters.size(); i++)
       {
         if (!data.parameters[i].empty())
@@ -49,14 +49,14 @@ void rychkov::CParser::parse_open_brace(CParseContext& context)
     }
     decl.value = entities::Body{};
     stack_.push(&*decl.value);
-    entities::Body& body = boost::variant2::get< entities::Body >(stack_.top()->operands[0]);
+    entities::Body& body = get< entities::Body >(stack_.top()->operands[0]);
     stack_.push(&body.data[0]);
     return;
   }
   if (stack_.top()->empty())
   {
     stack_.top()->operands.emplace_back(entities::Body{});
-    entities::Body& body = boost::variant2::get< entities::Body >(stack_.top()->operands[0]);
+    entities::Body& body = get< entities::Body >(stack_.top()->operands[0]);
     stack_.push(&body.data[0]);
     return;
   }
@@ -75,22 +75,22 @@ void rychkov::CParser::parse_close_brace(CParseContext& context)
   }
   if (entities::is_body(*stack_.top()))
   {
-    entities::Body& body = boost::variant2::get< entities::Body >(stack_.top()->operands[0]);
+    entities::Body& body = get< entities::Body >(stack_.top()->operands[0]);
     body.data.pop_back();
     stack_.pop();
     clear_scope();
     if (entities::is_decl(*stack_.top()))
     {
-      entities::Declaration& decl = boost::variant2::get< entities::Declaration >(stack_.top()->operands[0]);
-      if (boost::variant2::holds_alternative< entities::Struct >(decl.data))
+      entities::Declaration& decl = get< entities::Declaration >(stack_.top()->operands[0]);
+      if (holds_alternative< entities::Struct >(decl.data))
       {
-        entities::Struct& structure = boost::variant2::get< entities::Struct >(decl.data);
+        entities::Struct& structure = get< entities::Struct >(decl.data);
         for (const entities::Expression& i: body.data)
         {
           if (entities::is_decl(i))
           {
-            const entities::Declaration& var_decl = boost::variant2::get< entities::Declaration >(i.operands[0]);
-            if (!boost::variant2::holds_alternative< entities::Variable >(var_decl.data))
+            const entities::Declaration& var_decl = get< entities::Declaration >(i.operands[0]);
+            if (!holds_alternative< entities::Variable >(var_decl.data))
             {
               log(context, "struct body must consist only of variable declarations");
               continue;
@@ -100,7 +100,7 @@ void rychkov::CParser::parse_close_brace(CParseContext& context)
               log(context, "struct fields cannot have default values");
               continue;
             }
-            const entities::Variable& var = boost::variant2::get< entities::Variable >(var_decl.data);
+            const entities::Variable& var = get< entities::Variable >(var_decl.data);
             if (structure.fields.find(var.name) == structure.fields.end())
             {
               structure.fields.insert(var);
@@ -115,14 +115,14 @@ void rychkov::CParser::parse_close_brace(CParseContext& context)
           }
         }
       }
-      if (boost::variant2::holds_alternative< entities::Function >(decl.data))
+      if (holds_alternative< entities::Function >(decl.data))
       {
         program_.emplace_back();
         stack_.top() = &program_.back();
       }
-      if (boost::variant2::holds_alternative< entities::Statement >(decl.data))
+      if (holds_alternative< entities::Statement >(decl.data))
       {
-        entities::Statement& statement = boost::variant2::get< entities::Statement >(decl.data);
+        entities::Statement& statement = get< entities::Statement >(decl.data);
         if ((statement.type == entities::Statement::IF) || (statement.type == entities::Statement::WHILE))
         {
           stack_.pop();
@@ -134,9 +134,9 @@ void rychkov::CParser::parse_close_brace(CParseContext& context)
     }
     else if (entities::is_body(*stack_.top()))
     {
-      entities::Body& body = boost::variant2::get< entities::Body >(stack_.top()->operands[0]);
-      body.data.emplace_back();
-      stack_.push(&body.data.back());
+      entities::Body& upper_body = get< entities::Body >(stack_.top()->operands[0]);
+      upper_body.data.emplace_back();
+      stack_.push(&upper_body.data.back());
     }
     return;
   }

--- a/rychkov.mihail/F0/parse_folding.cpp
+++ b/rychkov.mihail/F0/parse_folding.cpp
@@ -1,0 +1,66 @@
+#include "cparser.hpp"
+
+void rychkov::CParser::fold(CParseContext& context, const Operator* reference)
+{
+  if ((reference != nullptr) && entities::is_bridge(*stack_.top()))
+  {
+    move_up_down();
+    stack_.top()->operation = reference;
+    return;
+  }
+  entities::Expression* last = stack_.top();
+  while (entities::is_operator(*stack_.top()))
+  {
+    if ((stack_.top()->operation == &inline_if) && (reference == &inline_if))
+    {
+      return;
+    }
+    if (!stack_.top()->full())
+    {
+      log(context, "found not full operator during priority folding");
+    }
+    if ((reference != nullptr) && ((stack_.top()->operation->priority > reference->priority)
+        || ((stack_.top()->operation->priority == reference->priority) && reference->right_align)))
+    {
+      move_down();
+      stack_.top()->operation = reference;
+      return;
+    }
+    last = stack_.top();
+    calculate_type(context, *last);
+    stack_.pop();
+  }
+  if (reference != nullptr)
+  {
+    stack_.push(last);
+    move_up();
+    stack_.top()->operation = reference;
+    return;
+  }
+}
+rychkov::entities::Expression* rychkov::CParser::move_up()
+{
+  entities::Expression* temp = new entities::Expression{std::move(*stack_.top())};
+  stack_.top()->operation = nullptr;
+  stack_.top()->operands.push_back(temp);
+  return temp;
+}
+void rychkov::CParser::move_down()
+{
+  entities::Expression* temp = new entities::Expression{nullptr, {std::move(stack_.top()->operands.back())}};
+  stack_.top()->operands.back() = temp;
+  stack_.push(temp);
+}
+void rychkov::CParser::move_up_down()
+{
+  stack_.push(move_up());
+}
+
+void rychkov::CParser::clear_scope()
+{
+  clear_scope(base_types, stack_.size());
+  clear_scope(variables, stack_.size());
+  clear_scope(structs, stack_.size());
+  clear_scope(unions, stack_.size());
+  clear_scope(enums, stack_.size());
+}

--- a/rychkov.mihail/F0/parse_keywords.cpp
+++ b/rychkov.mihail/F0/parse_keywords.cpp
@@ -1,0 +1,98 @@
+#include "cparser.hpp"
+
+void rychkov::CParser::parse_typedef(CParseContext& context)
+{
+  if (global_scope())
+  {
+    stack_.top()->operands.push_back(entities::Declaration{entities::Alias{}});
+    return;
+  }
+  log(context, "typedef cannot be declared in this scope");
+  return;
+}
+void rychkov::CParser::parse_struct(CParseContext& context)
+{
+  if (global_scope() || stack_.top()->empty())
+  {
+    stack_.top()->operands.push_back(entities::Declaration{entities::Struct{}});
+    return;
+  }
+  log(context, "struct cannot be declared in this context");
+  return;
+}
+void rychkov::CParser::parse_union(CParseContext& context)
+{
+  if (global_scope() || stack_.top()->empty())
+  {
+    stack_.top()->operands.push_back(entities::Declaration{entities::Union{}});
+    return;
+  }
+  log(context, "union cannot be declared in this context");
+  return;
+}
+void rychkov::CParser::parse_enum(CParseContext& context)
+{
+  if (global_scope() || stack_.top()->empty())
+  {
+    stack_.top()->operands.push_back(entities::Declaration{entities::Enum{}});
+    return;
+  }
+  log(context, "enum cannot be declared in this context");
+  return;
+}
+void rychkov::CParser::parse_return(CParseContext& context)
+{
+  if (stack_.top()->empty())
+  {
+    entities::Expression* temp = new entities::Expression;
+    stack_.top()->operands.push_back(entities::Declaration{entities::Statement{entities::Statement::RETURN}, temp});
+    stack_.push(temp);
+    return;
+  }
+  log(context, "return cannot be declared in this context");
+  return;
+}
+void rychkov::CParser::parse_if(CParseContext& context)
+{
+  check_statement_placement(context);
+  if (stack_.top()->empty())
+  {
+    stack_.top()->operands.push_back(entities::Declaration{entities::Statement{entities::Statement::IF}});
+    return;
+  }
+  log(context, "if cannot be declared in this context");
+  return;
+}
+void rychkov::CParser::parse_while(CParseContext& context)
+{
+  check_statement_placement(context);
+  if (stack_.top()->empty())
+  {
+    stack_.top()->operands.push_back(entities::Declaration{entities::Statement{entities::Statement::WHILE}});
+    return;
+  }
+  log(context, "while cannot be declared in this context");
+  return;
+}
+void rychkov::CParser::check_statement_placement(CParseContext& context)
+{
+  entities::Expression* last = stack_.top();
+  stack_.pop();
+  if (entities::is_decl(*stack_.top()))
+  {
+    entities::Declaration& decl = boost::variant2::get< entities::Declaration >(stack_.top()->operands[0]);
+    if ((last != &*decl.value) || !boost::variant2::holds_alternative< entities::Statement >(decl.data))
+    {
+      log(context, "cannot place statement here");
+    }
+    else
+    {
+      entities::Statement& statement = boost::variant2::get< entities::Statement >(decl.data);
+      if (statement.type == entities::Statement::RETURN)
+      {
+        log(context, "cannot place statement as return result");
+      }
+    }
+  }
+  stack_.push(last);
+}

--- a/rychkov.mihail/F0/parse_keywords.cpp
+++ b/rychkov.mihail/F0/parse_keywords.cpp
@@ -80,14 +80,14 @@ void rychkov::CParser::check_statement_placement(CParseContext& context)
   stack_.pop();
   if (entities::is_decl(*stack_.top()))
   {
-    entities::Declaration& decl = boost::variant2::get< entities::Declaration >(stack_.top()->operands[0]);
-    if ((last != &*decl.value) || !boost::variant2::holds_alternative< entities::Statement >(decl.data))
+    entities::Declaration& decl = get< entities::Declaration >(stack_.top()->operands[0]);
+    if ((last != &*decl.value) || !holds_alternative< entities::Statement >(decl.data))
     {
       log(context, "cannot place statement here");
     }
     else
     {
-      entities::Statement& statement = boost::variant2::get< entities::Statement >(decl.data);
+      entities::Statement& statement = get< entities::Statement >(decl.data);
       if (statement.type == entities::Statement::RETURN)
       {
         log(context, "cannot place statement as return result");

--- a/rychkov.mihail/F0/parse_operator.cpp
+++ b/rychkov.mihail/F0/parse_operator.cpp
@@ -1,0 +1,102 @@
+#include "cparser.hpp"
+
+void rychkov::CParser::append(CParseContext& context, const std::vector< rychkov::Operator >& cases)
+{
+  if (!type_parser_.empty())
+  {
+    if (cases[0].token == "*")
+    {
+      return append(context, '*');
+    }
+    if (!flush_type_parser(context))
+    {
+      log(context, "operator" + cases[0].token + " cannot be parsed here");
+      return;
+    }
+  }
+
+  if (global_scope())
+  {
+    log(context, "operators cannot be in global scope");
+    return;
+  }
+
+  if ((cases.size() == 1) && (cases[0].category == Operator::ASSIGN))
+  {
+    if (entities::is_decl(*stack_.top()))
+    {
+      entities::Declaration& decl = boost::variant2::get< entities::Declaration >(stack_.top()->operands[0]);
+      if (boost::variant2::holds_alternative< entities::Variable >(decl.data))
+      {
+        decl.value = entities::Expression{};
+        stack_.push(&*decl.value);
+        return;
+      }
+      log(context, "unexpected assign");
+      return;
+    }
+  }
+
+  bool result = false;
+  if (cases.size() == 2)
+  {
+    if (cases[0].type == Operator::BINARY)
+    {
+      result = parse_binary(context, cases[0]) || parse_unary(context, cases[1]);
+    }
+    else if (cases[1].type == Operator::BINARY)
+    {
+      result = parse_binary(context, cases[1]) || parse_unary(context, cases[0]);
+    }
+    else
+    {
+      result = parse_unary(context, cases[0]) || parse_unary(context, cases[1]);
+    }
+  }
+  else if (cases[0].type == Operator::BINARY)
+  {
+    result = parse_binary(context, cases[0]);
+  }
+  else
+  {
+    result = parse_unary(context, cases[0]);
+  }
+  if (!result)
+  {
+    log(context, "cannot parse operator" + cases[0].token + " here");
+  }
+}
+bool rychkov::CParser::parse_binary(CParseContext& context, const rychkov::Operator& oper)
+{
+  if (!stack_.top()->full())
+  {
+    return false;
+  }
+  fold(context, &oper);
+  return true;
+}
+bool rychkov::CParser::parse_unary(CParseContext& context, const rychkov::Operator& oper)
+{
+  if (oper.right_align)
+  {
+    if ((!stack_.top()->empty() && entities::is_bridge(*stack_.top())) || stack_.top()->full())
+    {
+      return false;
+    }
+    entities::Expression* temp = new entities::Expression{&oper, {}};
+    stack_.top()->operands.push_back(temp);
+    stack_.push(temp);
+  }
+  else
+  {
+    if (!stack_.top()->full())
+    {
+      return false;
+    }
+    move_down();
+    stack_.top()->operation = &oper;
+    calculate_type(context, *stack_.top());
+    stack_.pop();
+  }
+  return true;
+}

--- a/rychkov.mihail/F0/parse_operator.cpp
+++ b/rychkov.mihail/F0/parse_operator.cpp
@@ -25,8 +25,8 @@ void rychkov::CParser::append(CParseContext& context, const std::vector< rychkov
   {
     if (entities::is_decl(*stack_.top()))
     {
-      entities::Declaration& decl = boost::variant2::get< entities::Declaration >(stack_.top()->operands[0]);
-      if (boost::variant2::holds_alternative< entities::Variable >(decl.data))
+      entities::Declaration& decl = get< entities::Declaration >(stack_.top()->operands[0]);
+      if (holds_alternative< entities::Variable >(decl.data))
       {
         decl.value = entities::Expression{};
         stack_.push(&*decl.value);

--- a/rychkov.mihail/F0/parse_semicolon.cpp
+++ b/rychkov.mihail/F0/parse_semicolon.cpp
@@ -1,0 +1,119 @@
+#include "cparser.hpp"
+
+#include <iostream>
+#include "print_content.hpp"
+
+void rychkov::CParser::parse_semicolon(CParseContext& context)
+{
+  bool not_first = false;
+  while (!stack_.empty() && !entities::is_body(*stack_.top()) && !entities::is_decl(*stack_.top()))
+  {
+    if (not_first)
+    {
+      log(context, "found not paired closed [] or () pair");
+      not_first = true;
+    }
+    fold(context, nullptr);
+    entities::remove_bridge(*stack_.top());
+    calculate_type(context, *stack_.top());
+    stack_.pop();
+  }
+  if (stack_.empty())
+  {
+    append_empty(context);
+    return;
+  }
+
+  if (entities::is_body(*stack_.top()))
+  {
+    entities::Body& body = boost::variant2::get< entities::Body >(stack_.top()->operands[0]);
+    body.data.emplace_back();
+    stack_.push(&body.data.back());
+    return;
+  }
+  if (entities::is_decl(*stack_.top()))
+  {
+    entities::Declaration& decl = boost::variant2::get< entities::Declaration >(stack_.top()->operands[0]);
+    if (boost::variant2::holds_alternative< entities::Struct >(decl.data))
+    {
+      entities::Struct& data = boost::variant2::get< entities::Struct >(decl.data);
+      if (data.name.empty())
+      {
+        log(context, "struct must have name");
+        return;
+      }
+      stack_.pop();
+      structs.insert(std::make_pair(data, stack_.size()));
+      base_types.insert(std::make_pair(typing::Type{data.name, typing::STRUCT}, stack_.size()));
+      append_empty(context);
+      return;
+    }
+    if (boost::variant2::holds_alternative< entities::Variable >(decl.data))
+    {
+      entities::Variable& data = boost::variant2::get< entities::Variable >(decl.data);
+      if (data.name.empty())
+      {
+        log(context, "variable must have name");
+        return;
+      }
+      if (decl.value != nullptr)
+      {
+        require_type(context, *decl.value, data.type);
+      }
+      if (typing::is_array(&data.type) && !data.type.array_has_length)
+      {
+        if (decl.value != nullptr)
+        {
+          if (!decl.value->result_type.array_has_length)
+          {
+            log(context, "cannot deduce array length");
+          }
+          else
+          {
+            data.type.array_has_length = true;
+            data.type.array_length = decl.value->result_type.array_length;
+          }
+        }
+      }
+      stack_.pop();
+      append_empty(context);
+      return;
+    }
+    if (boost::variant2::holds_alternative< entities::Function >(decl.data))
+    {
+      stack_.pop();
+      append_empty(context);
+      return;
+    }
+    if (boost::variant2::holds_alternative< entities::Alias >(decl.data))
+    {
+      entities::Alias& data = boost::variant2::get< entities::Alias >(decl.data);
+      if (data.name.empty())
+      {
+        log(context, "missing alias name");
+      }
+      else
+      {
+        aliases.insert(data);
+      }
+      stack_.pop();
+      append_empty(context);
+      return;
+    }
+    if (boost::variant2::holds_alternative< entities::Statement >(decl.data))
+    {
+      entities::Statement& data = boost::variant2::get< entities::Statement >(decl.data);
+      if ((data.type == entities::Statement::RETURN) || (data.type == entities::Statement::IF)
+          || (data.type == entities::Statement::WHILE))
+      {
+        stack_.pop();
+        append_empty(context);
+        clear_scope();
+        return;
+      }
+    }
+    log(context, "cannot parse ';' here");
+  }
+  program_.emplace_back();
+  stack_.push(&program_.back());
+}

--- a/rychkov.mihail/F0/parse_semicolon.cpp
+++ b/rychkov.mihail/F0/parse_semicolon.cpp
@@ -26,17 +26,17 @@ void rychkov::CParser::parse_semicolon(CParseContext& context)
 
   if (entities::is_body(*stack_.top()))
   {
-    entities::Body& body = boost::variant2::get< entities::Body >(stack_.top()->operands[0]);
+    entities::Body& body = get< entities::Body >(stack_.top()->operands[0]);
     body.data.emplace_back();
     stack_.push(&body.data.back());
     return;
   }
   if (entities::is_decl(*stack_.top()))
   {
-    entities::Declaration& decl = boost::variant2::get< entities::Declaration >(stack_.top()->operands[0]);
-    if (boost::variant2::holds_alternative< entities::Struct >(decl.data))
+    entities::Declaration& decl = get< entities::Declaration >(stack_.top()->operands[0]);
+    if (holds_alternative< entities::Struct >(decl.data))
     {
-      entities::Struct& data = boost::variant2::get< entities::Struct >(decl.data);
+      entities::Struct& data = get< entities::Struct >(decl.data);
       if (data.name.empty())
       {
         log(context, "struct must have name");
@@ -48,9 +48,9 @@ void rychkov::CParser::parse_semicolon(CParseContext& context)
       append_empty(context);
       return;
     }
-    if (boost::variant2::holds_alternative< entities::Variable >(decl.data))
+    if (holds_alternative< entities::Variable >(decl.data))
     {
-      entities::Variable& data = boost::variant2::get< entities::Variable >(decl.data);
+      entities::Variable& data = get< entities::Variable >(decl.data);
       if (data.name.empty())
       {
         log(context, "variable must have name");
@@ -79,15 +79,15 @@ void rychkov::CParser::parse_semicolon(CParseContext& context)
       append_empty(context);
       return;
     }
-    if (boost::variant2::holds_alternative< entities::Function >(decl.data))
+    if (holds_alternative< entities::Function >(decl.data))
     {
       stack_.pop();
       append_empty(context);
       return;
     }
-    if (boost::variant2::holds_alternative< entities::Alias >(decl.data))
+    if (holds_alternative< entities::Alias >(decl.data))
     {
-      entities::Alias& data = boost::variant2::get< entities::Alias >(decl.data);
+      entities::Alias& data = get< entities::Alias >(decl.data);
       if (data.name.empty())
       {
         log(context, "missing alias name");
@@ -100,9 +100,9 @@ void rychkov::CParser::parse_semicolon(CParseContext& context)
       append_empty(context);
       return;
     }
-    if (boost::variant2::holds_alternative< entities::Statement >(decl.data))
+    if (holds_alternative< entities::Statement >(decl.data))
     {
-      entities::Statement& data = boost::variant2::get< entities::Statement >(decl.data);
+      entities::Statement& data = get< entities::Statement >(decl.data);
       if ((data.type == entities::Statement::RETURN) || (data.type == entities::Statement::IF)
           || (data.type == entities::Statement::WHILE))
       {

--- a/rychkov.mihail/F0/parse_specials.cpp
+++ b/rychkov.mihail/F0/parse_specials.cpp
@@ -1,0 +1,133 @@
+#include "cparser.hpp"
+
+void rychkov::CParser::parse_open_parenthesis(CParseContext& context)
+{
+  if (entities::is_decl(*stack_.top()))
+  {
+    entities::Declaration& decl = boost::variant2::get< entities::Declaration >(stack_.top()->operands[0]);
+    if (boost::variant2::holds_alternative< entities::Statement >(decl.data))
+    {
+      entities::Statement& statement = boost::variant2::get< entities::Statement >(decl.data);
+      if ((statement.type == entities::Statement::IF) || (statement.type == entities::Statement::WHILE))
+      {
+        statement.conditions.emplace_back();
+        stack_.push(&statement.conditions.back());
+        return;
+      }
+    }
+    log(context, "unexpected '('");
+    return;
+  }
+  if (stack_.top()->full())
+  {
+    move_down();
+    stack_.top()->operation = &parentheses;
+  }
+  entities::Expression* temp = new entities::Expression;
+  stack_.top()->operands.push_back(temp);
+  stack_.push(temp);
+}
+void rychkov::CParser::parse_close_parenthesis(CParseContext& context)
+{
+  fold(context, nullptr);
+  entities::Expression* last = stack_.top();
+  stack_.pop();
+  if (entities::is_decl(*stack_.top()))
+  {
+    entities::Declaration& decl = boost::variant2::get< entities::Declaration >(stack_.top()->operands[0]);
+    if (boost::variant2::holds_alternative< entities::Statement >(decl.data))
+    {
+      entities::Statement& statement = boost::variant2::get< entities::Statement >(decl.data);
+      if ((statement.type == entities::Statement::IF) || (statement.type == entities::Statement::WHILE))
+      {
+        if (!statement.conditions.empty() && (last == &statement.conditions.back()))
+        {
+          remove_bridge(*last);
+          calculate_type(context, *last);
+          require_type(context, statement.conditions[0], {"int", typing::BASIC});
+          entities::Expression* temp = new entities::Expression;
+          decl.value = temp;
+          stack_.push(temp);
+          return;
+        }
+      }
+    }
+    log(context, "found not paired ')'");
+    stack_.push(last);
+    return;
+  }
+  if (entities::is_body(*stack_.top()))
+  {
+    log(context, "found not paired ')'");
+    stack_.push(last);
+    return;
+  }
+  remove_bridge(*last);
+  calculate_type(context, *last);
+  if (stack_.top()->operation == &parentheses)
+  {
+    calculate_type(context, *stack_.top());
+    stack_.pop();
+  }
+}
+void rychkov::CParser::parse_open_bracket(CParseContext& context)
+{
+  if (!stack_.top()->full())
+  {
+    log(context, "operator[] cannot be applied here");
+    return;
+  }
+  move_down();
+  stack_.top()->operation = &brackets;
+  entities::Expression* temp = new entities::Expression;
+  stack_.top()->operands.push_back(temp);
+  stack_.push(temp);
+}
+void rychkov::CParser::parse_close_bracket(CParseContext& context)
+{
+  fold(context, nullptr);
+  entities::Expression* last = stack_.top();
+  stack_.pop();
+  if (stack_.top()->operation != &brackets)
+  {
+    log(context, "found not paired ']'");
+    stack_.push(last);
+    return;
+  }
+  remove_bridge(*last);
+  calculate_type(context, *last);
+  calculate_type(context, *stack_.top());
+  stack_.pop();
+}
+void rychkov::CParser::parse_comma(CParseContext& context)
+{
+  fold(context, nullptr);
+  entities::Expression* last = stack_.top();
+  stack_.pop();
+  if (stack_.top()->operation == &parentheses)
+  {
+    remove_bridge(*last);
+    entities::Expression* temp = new entities::Expression{};
+    stack_.top()->operands.push_back(temp);
+    stack_.push(temp);
+    return;
+  }
+  stack_.push(last);
+  if (entities::is_bridge(*last))
+  {
+    move_up_down();
+    stack_.top()->operation = &comma;
+    return;
+  }
+  move_up();
+  stack_.top()->operation = &comma;
+}
+void rychkov::CParser::parse_question_mark(CParseContext& context)
+{
+  fold(context, &inline_if);
+  stack_.top()->operation = &inline_if;
+}
+void rychkov::CParser::parse_colon(CParseContext& context)
+{
+  fold(context, &inline_if);
+}

--- a/rychkov.mihail/F0/parse_specials.cpp
+++ b/rychkov.mihail/F0/parse_specials.cpp
@@ -4,10 +4,10 @@ void rychkov::CParser::parse_open_parenthesis(CParseContext& context)
 {
   if (entities::is_decl(*stack_.top()))
   {
-    entities::Declaration& decl = boost::variant2::get< entities::Declaration >(stack_.top()->operands[0]);
-    if (boost::variant2::holds_alternative< entities::Statement >(decl.data))
+    entities::Declaration& decl = get< entities::Declaration >(stack_.top()->operands[0]);
+    if (holds_alternative< entities::Statement >(decl.data))
     {
-      entities::Statement& statement = boost::variant2::get< entities::Statement >(decl.data);
+      entities::Statement& statement = get< entities::Statement >(decl.data);
       if ((statement.type == entities::Statement::IF) || (statement.type == entities::Statement::WHILE))
       {
         statement.conditions.emplace_back();
@@ -34,10 +34,10 @@ void rychkov::CParser::parse_close_parenthesis(CParseContext& context)
   stack_.pop();
   if (entities::is_decl(*stack_.top()))
   {
-    entities::Declaration& decl = boost::variant2::get< entities::Declaration >(stack_.top()->operands[0]);
-    if (boost::variant2::holds_alternative< entities::Statement >(decl.data))
+    entities::Declaration& decl = get< entities::Declaration >(stack_.top()->operands[0]);
+    if (holds_alternative< entities::Statement >(decl.data))
     {
-      entities::Statement& statement = boost::variant2::get< entities::Statement >(decl.data);
+      entities::Statement& statement = get< entities::Statement >(decl.data);
       if ((statement.type == entities::Statement::IF) || (statement.type == entities::Statement::WHILE))
       {
         if (!statement.conditions.empty() && (last == &statement.conditions.back()))

--- a/rychkov.mihail/F0/parse_type_calculating.cpp
+++ b/rychkov.mihail/F0/parse_type_calculating.cpp
@@ -1,0 +1,287 @@
+#include "cparser.hpp"
+
+#include <iostream>
+#include "print_content.hpp"
+
+void rychkov::CParser::calculate_type(CParseContext& context, entities::Expression& expr)
+{
+  expr.result_type = {};
+  if (entities::is_operator(expr) && (expr.operation != &comma))
+  {
+    if (!expr.full())
+    {
+      return;
+    }
+    if (expr.operation->require_lvalue && !entities::is_lvalue(expr.operands[0]))
+    {
+      log(context, "operator" + expr.operation->token + " requires lvalue");
+      return;
+    }
+    for (const entities::Expression::operand& arg: expr.operands)
+    {
+      const typing::Type* type_p = entities::get_type(arg);
+      if (type_p == nullptr)
+      {
+        return;
+      }
+      if (type_p->name == "void")
+      {
+        log(context, "operator cannot be applied to void");
+        return;
+      }
+    }
+    switch (expr.operation->category)
+    {
+    case Operator::FIELD_ACCESS:
+      expr.result_type = *entities::get_type(expr.operands[1]);
+      return;
+    case Operator::SPECIAL:
+      if (expr.operation == &brackets)
+      {
+        const typing::Type* iterable = entities::get_type(expr.operands[0]);
+        if (!typing::is_iterable(iterable))
+        {
+          log(context, "operator[] must be applied to iterable type");
+        }
+        if (!typing::is_integer(entities::get_type(expr.operands[1])))
+        {
+          log(context, "operator[] argument must be integer");
+        }
+        else
+        {
+          expr.result_type = *iterable->base;
+        }
+      }
+      if (expr.operation == &inline_if)
+      {
+        const typing::Type* main_body = entities::get_type(expr.operands[1]);
+        const typing::Type* else_body = entities::get_type(expr.operands[2]);
+        const typing::Type* common = typing::common_type(*main_body, *else_body);
+        if (common == nullptr)
+        {
+          log(context, "operator?: must be applied to basic types");
+          return;
+        }
+        require_type(context, expr.operands[0], {"int", typing::BASIC});
+        require_type(context, expr.operands[1], *common);
+        require_type(context, expr.operands[2], *common);
+        expr.result_type = *common;
+      }
+      return;
+    case Operator::DEREFERENCE:
+    {
+      const typing::Type* iterable = entities::get_type(expr.operands[0]);
+      if (!typing::is_iterable(iterable))
+      {
+        start_log(context) << "cannot dereference " << *iterable;
+        finish_log(context);
+        return;
+      }
+      expr.result_type = *iterable->base;
+      return;
+    }
+    case Operator::ADDRESSOF:
+      expr.result_type = {{}, typing::POINTER, *entities::get_type(expr.operands[0])};
+      return;
+    case Operator::INCREMENT:
+    {
+      const typing::Type* child = entities::get_type(expr.operands[0]);
+      if (!typing::is_integer(child) && !(is_pointer(child)))
+      {
+        start_log(context) << "operator" << expr.operation->token << " cannot be applied to " << *child;
+        finish_log(context);
+        return;
+      }
+      expr.result_type = *child;
+      return;
+    }
+    case Operator::ARITHMETIC:
+    {
+      if (expr.operation->type == Operator::BINARY)
+      {
+        break;
+      }
+      const typing::Type* basic = entities::get_type(expr.operands[0]);
+      if (!typing::is_basic(basic))
+      {
+        start_log(context) << "operator" << expr.operation->token << " cannot be applied to " << *basic;
+        finish_log(context);
+        return;
+      }
+      expr.result_type = *basic;
+      return;
+    }
+    case Operator::BIT:
+    {
+      if (expr.operation->type == Operator::BINARY)
+      {
+        break;
+      }
+      const typing::Type* integer = entities::get_type(expr.operands[0]);
+      if (!typing::is_integer(integer))
+      {
+        log(context, "operator~ requires an integer");
+        return;
+      }
+      expr.result_type = *integer;
+      return;
+    }
+    case Operator::LOGIC:
+      if (expr.operation->type == Operator::BINARY)
+      {
+        break;
+      }
+      expr.result_type = {"int", typing::BASIC};
+      require_type(context, expr.operands[0], expr.result_type);
+      return;
+    default:
+      break;
+    }
+
+    const typing::Type* lhs = entities::get_type(expr.operands[0]);
+    const typing::Type* rhs = entities::get_type(expr.operands[1]);
+    switch (expr.operation->category)
+    {
+    case Operator::ARITHMETIC:
+    {
+      const typing::Type* common = typing::common_type(*lhs, *rhs);
+      if (common == nullptr)
+      {
+        start_log(context) << "operator" << expr.operation->token << " must be applied to basic types";
+        finish_log(context);
+        return;
+      }
+      if (expr.operation->require_lvalue)
+      {
+        require_type(context, expr.operands[1], *lhs);
+        expr.result_type = *lhs;
+        return;
+      }
+      require_type(context, expr.operands[0], *common);
+      require_type(context, expr.operands[1], *common);
+      expr.result_type = *common;
+      return;
+    }
+    case Operator::LOGIC:
+      expr.result_type = {"int", typing::BASIC};
+      require_type(context, expr.operands[0], expr.result_type);
+      require_type(context, expr.operands[1], expr.result_type);
+      return;
+    case Operator::COMPARE:
+    {
+      expr.result_type = {"int", typing::BASIC};
+      const typing::Type* common = typing::common_type(*lhs, *rhs);
+      if (common == nullptr)
+      {
+        if (pointer_comparable(*lhs, *rhs))
+        {
+          return;
+        }
+        start_log(context) << "operator" << expr.operation->token << " must be applied to basic types";
+        finish_log(context);
+        return;
+      }
+      require_type(context, expr.operands[0], *common);
+      require_type(context, expr.operands[1], *common);
+      return;
+    }
+    case Operator::MODULUS:
+    case Operator::BIT:
+    {
+      const typing::Type* common = typing::largest_integer(*lhs, *rhs);
+      if (common == nullptr)
+      {
+        start_log(context) << "operator" << expr.operation->token << " must be applied to integers";
+        finish_log(context);
+        return;
+      }
+      if (expr.operation->require_lvalue)
+      {
+        require_type(context, expr.operands[1], *lhs);
+        expr.result_type = *lhs;
+        return;
+      }
+      require_type(context, expr.operands[0], *common);
+      require_type(context, expr.operands[1], *common);
+      expr.result_type = *common;
+      return;
+    }
+    case Operator::ASSIGN:
+      expr.result_type = *lhs;
+      require_type(context, expr.operands[1], *lhs);
+      return;
+    default:
+      break;
+    }
+    return;
+  }
+  if (!expr.operands.empty())
+  {
+    const typing::Type* temp = entities::get_type(expr.operands.back());
+    expr.result_type = (temp == nullptr ? typing::Type{} : *temp);
+  }
+}
+void rychkov::CParser::require_type(CParseContext& context, entities::Expression::operand& expr,
+    const typing::Type& type)
+{
+  const typing::Type* from = entities::get_type(expr);
+  if (from == nullptr)
+  {
+    log(context, "cannot use this expression as type");
+    return;
+  }
+  switch (typing::check_cast(type, *from))
+  {
+  case typing::EXACT:
+    break;
+  case typing::IMPLICIT:
+  {
+    entities::CastOperation temp = {type, false, entities::Expression{nullptr, {std::move(expr)}}};
+    expr = std::move(temp);
+    break;
+  }
+  case typing::NO_CAST:
+    start_log(context) << "cannot cast " << *from << " to " << type;
+    finish_log(context);
+    break;
+  }
+}
+void rychkov::CParser::require_type(CParseContext& context, entities::Expression& expr,
+    const typing::Type& type)
+{
+  if (!expr.result_type.ready())
+  {
+    log(context, "cannot use this expression as type");
+    return;
+  }
+  switch (typing::check_cast(type, expr.result_type))
+  {
+  case typing::EXACT:
+    break;
+  case typing::IMPLICIT:
+  {
+    entities::CastOperation temp = {type, false, std::move(expr)};
+    expr = std::move(temp);
+    calculate_type(context, *boost::variant2::get< entities::CastOperation >(expr.operands[0]).expr);
+    break;
+  }
+  case typing::NO_CAST:
+    start_log(context) << "cannot cast " << expr.result_type << " to " << type;
+    finish_log(context);
+    break;
+  }
+}
+std::pair< const rychkov::entities::Variable*, rychkov::typing::MatchType > rychkov::CParser::find_overload
+    (const std::string& name, const std::vector< typing::Type >& args)
+{
+  using Iter = decltype(defined_functions)::iterator;
+  std::pair< Iter, Iter > range = defined_functions.equal_range(name);
+  for (; range.first != range.second; ++range.first)
+  {
+    if (typing::check_overload(range.first->type, args) == typing::EXACT)
+    {
+      return {&*range.first, typing::EXACT};
+    }
+  }
+  return {nullptr, typing::NO_CAST};
+}

--- a/rychkov.mihail/F0/parse_type_calculating.cpp
+++ b/rychkov.mihail/F0/parse_type_calculating.cpp
@@ -262,7 +262,7 @@ void rychkov::CParser::require_type(CParseContext& context, entities::Expression
   {
     entities::CastOperation temp = {type, false, std::move(expr)};
     expr = std::move(temp);
-    calculate_type(context, *boost::variant2::get< entities::CastOperation >(expr.operands[0]).expr);
+    calculate_type(context, *get< entities::CastOperation >(expr.operands[0]).expr);
     break;
   }
   case typing::NO_CAST:

--- a/rychkov.mihail/F0/preprocessor.cpp
+++ b/rychkov.mihail/F0/preprocessor.cpp
@@ -1,0 +1,237 @@
+#include "preprocessor.hpp"
+
+#include <iostream>
+#include <sstream>
+#include <cctype>
+#include <utility>
+#include "lexer.hpp"
+
+rychkov::Preprocessor::Preprocessor():
+  next{nullptr}
+{}
+rychkov::Preprocessor::Preprocessor(std::unique_ptr< Lexer > lexer, std::vector< std::string > search_dirs):
+  include_paths(std::move(search_dirs)),
+  next{std::move(lexer)}
+{}
+
+bool rychkov::Preprocessor::skip_all() const noexcept
+{
+  return !conditional_pairs_.empty() && ((conditional_pairs_.top() == WAIT_ELSE)
+      || (conditional_pairs_.top() == SKIP_ELSE));
+}
+std::string rychkov::Preprocessor::get_name(std::istream& in)
+{
+  std::string name;
+  for (; in && (std::isalnum(in.peek()) || (in.peek() == '_')); name += in.get())
+  {}
+  return name;
+}
+void rychkov::Preprocessor::remove_whitespaces(std::string& str)
+{
+  std::string::size_type pos = str.find_last_not_of(" \t\v\n\r");
+  if ((pos != std::string::npos) && (pos + 1 < str.length()))
+  {
+    str.erase(pos + 1);
+  }
+  pos = str.find_first_not_of(" \t\v\n\r");
+  if (pos != std::string::npos)
+  {
+    str.erase(0, pos);
+  }
+}
+void rychkov::Preprocessor::flush(CParseContext& context, char c)
+{
+  if ((state_ == DIRECTIVE) || (state_ == MACRO_PARAMETERS))
+  {
+    buf_ += c;
+  }
+  else if (!skip_all())
+  {
+    if (next == nullptr)
+    {
+      context.out << c;
+    }
+    else
+    {
+      next->append(context, c);
+    }
+  }
+}
+void rychkov::Preprocessor::flush_buf(CParseContext& context)
+{
+  if (state_ == DIRECTIVE)
+  {
+    state_ = NO_STATE;
+    prev_state_ = NO_STATE;
+    std::istringstream in(buf_);
+    std::string cmd;
+    in >> std::noskipws >> cmd >> std::skipws;
+    if (!skip_all() || (cmd == "endif") || (cmd == "else"))
+    {
+      decltype(directives_)::const_iterator cmd_p = directives_.find(cmd);
+      if (cmd_p == directives_.cend())
+      {
+        log(context, "unknown preprocessor command");
+      }
+      else
+      {
+        (this->*(cmd_p->second))(in, context);
+      }
+    }
+    buf_.clear();
+    return;
+  }
+  if (!skip_all())
+  {
+    if (state_ == MACRO_PARAMETERS)
+    {
+      log(context, "expansion of macro hasn't finished - aborting");
+      expansion_ = nullptr;
+      expansion_list_.clear();
+    }
+    else
+    {
+      if (state_ == NAME)
+      {
+        decltype(macros)::iterator macro_p = macros.find(buf_);
+        if (macro_p != macros.end())
+        {
+          if (macro_p->func_style)
+          {
+            state_ = MACRO_PARAMETERS;
+            prev_state_ = NO_STATE;
+            expansion_ = &*macro_p;
+            parentheses_depth_ = 0;
+            buf_.clear();
+            return;
+          }
+          expansion_ = &*macro_p;
+          state_ = prev_state_;
+          prev_state_ = NO_STATE;
+          expanse_macro(context);
+          flush_buf(context);
+          buf_.clear();
+          return;
+        }
+      }
+      State prev = state_;
+      state_ = prev_state_;
+      if ((state_ == DIRECTIVE) || (state_ == MACRO_PARAMETERS))
+      {
+        return;
+      }
+      if (!skip_all())
+      {
+        if (next == nullptr)
+        {
+          for (char c: buf_)
+          {
+            flush(context, c);
+          }
+        }
+        else
+        {
+          switch (prev)
+          {
+          case rychkov::Preprocessor::STRING_LITERAL:
+            next->append_string_literal(context, buf_);
+            break;
+          case rychkov::Preprocessor::CHAR_LITERAL:
+            next->append_char_literal(context, buf_);
+            break;
+          case rychkov::Preprocessor::NAME:
+            next->append_name(context, buf_);
+            break;
+          case rychkov::Preprocessor::NUMBER:
+            next->append_number(context, buf_);
+            break;
+          default:
+            for (char c: buf_)
+            {
+              flush(context, c);
+            }
+            break;
+          }
+        }
+      }
+    }
+  }
+  state_ = prev_state_;
+  prev_state_ = NO_STATE;
+  buf_.clear();
+}
+void rychkov::Preprocessor::flush(CParseContext& context)
+{
+  flush_buf(context);
+  if (next != nullptr)
+  {
+    next->flush(context);
+  }
+  if (!conditional_pairs_.empty())
+  {
+    log(context, "not all #if-#else-#endif were closed");
+  }
+}
+void rychkov::Preprocessor::parse(CParseContext& context, std::istream& in, bool need_flush)
+{
+  bool not_first_line = false;
+  while (in.good())
+  {
+    if (not_first_line)
+    {
+      append(context, '\n');
+      context.line++;
+    }
+    not_first_line = true;
+    context.symbol = 0;
+    std::getline(in, context.last_line);
+    for (char c: context.last_line)
+    {
+      append(context, c);
+      context.symbol++;
+    }
+  }
+  if (need_flush)
+  {
+    flush(context);
+  }
+}
+void rychkov::Preprocessor::expanse_macro(CParseContext& context)
+{
+  const Macro* macro_p = std::exchange(expansion_, nullptr);
+  std::string body = macro_p->body;
+  if (macro_p->func_style)
+  {
+    remove_whitespaces(buf_);
+    if (!buf_.empty())
+    {
+      expansion_list_.push_back(std::move(buf_));
+    }
+    if (expansion_list_.size() > macro_p->parameters.size())
+    {
+      log(context, "too many arguments for expansion of macro " + macro_p->name);
+      expansion_list_.resize(macro_p->parameters.size());
+    }
+    for (size_t i = 0; i < expansion_list_.size(); i++)
+    {
+      std::string::size_type pos = body.find(macro_p->parameters[i]);
+      while (pos != std::string::npos)
+      {
+        body.replace(pos, macro_p->parameters[i].length(), expansion_list_[i]);
+        pos = body.find(macro_p->parameters[i]);
+      }
+    }
+    std::string::size_type pos = body.find("##");
+    while (pos != std::string::npos)
+    {
+      body.erase(pos, 2);
+      pos = body.find("##");
+    }
+    expansion_list_.clear();
+  }
+  buf_.clear();
+  std::istringstream in(body);
+  CParseContext expanse_context = {context.out, context.err, macro_p->name, &context, true};
+  parse(expanse_context, in, false);
+  context.nerrors += expanse_context.nerrors;
+}

--- a/rychkov.mihail/F0/preprocessor.hpp
+++ b/rychkov.mihail/F0/preprocessor.hpp
@@ -1,0 +1,98 @@
+#ifndef PREPROCESSOR_HPP
+#define PREPROCESSOR_HPP
+
+#include <cstddef>
+#include <iosfwd>
+#include <string>
+#include <vector>
+#include <stack>
+#include <set>
+#include <map>
+#include <memory>
+
+#include "log.hpp"
+#include "content.hpp"
+#include "compare.hpp"
+#include "lexer.hpp"
+
+namespace rychkov
+{
+  class Preprocessor
+  {
+  public:
+    std::vector< std::string > include_paths;
+    std::unique_ptr< Lexer > next;
+    std::set< Macro, NameCompare > macros;
+    std::multiset< Macro, NameCompare > legacy_macros;
+
+    Preprocessor();
+    Preprocessor(std::unique_ptr< Lexer > lexer, std::vector< std::string > search_dirs);
+
+    static std::string get_name(std::istream& in);
+    void parse(CParseContext& context, std::istream& in, bool need_flush = true);
+    void append(CParseContext& context, char c);
+    void flush(CParseContext& context);
+    void flush(CParseContext& context, char c);
+
+  private:
+    enum State
+    {
+      SINGLE_LINE_COMMENT,
+      MULTI_LINE_COMMENT,
+      STRING_LITERAL,
+      CHAR_LITERAL,
+      NAME,
+      NUMBER,
+      MACRO_PARAMETERS,
+      DIRECTIVE,
+      NO_STATE
+    };
+    enum IfStage
+    {
+      IF_BODY,
+      WAIT_ELSE,
+      ELSE_BODY,
+      SKIP_ELSE
+    };
+
+    const std::map< std::string, void(Preprocessor::*)(std::istream&, CParseContext&) > directives_ = {
+          {"include", &rychkov::Preprocessor::include},
+          {"define", &rychkov::Preprocessor::define},
+          {"pragma", &rychkov::Preprocessor::pragma},
+          {"undef", &rychkov::Preprocessor::undef},
+          {"ifdef", &rychkov::Preprocessor::ifdef},
+          {"ifndef", &rychkov::Preprocessor::ifndef},
+          {"else", &rychkov::Preprocessor::else_cmd},
+          {"endif", &rychkov::Preprocessor::endif}
+        };
+
+    char prev_ = '\0';
+    bool screened_ = false;
+    bool empty_line_ = true;
+    State state_ = NO_STATE;
+    State prev_state_ = NO_STATE;
+
+    const Macro* expansion_ = nullptr;
+    size_t parentheses_depth_ = 0;
+    std::vector< std::string > expansion_list_;
+
+    std::string buf_;
+    std::stack< IfStage > conditional_pairs_;
+
+    static void remove_whitespaces(std::string& str);
+    bool skip_all() const noexcept;
+    void flush_buf(CParseContext& context);
+    void expanse_macro(CParseContext& context);
+
+    void include(std::istream& in, CParseContext& context);
+    void define(std::istream& in, CParseContext& context);
+    void pragma(std::istream& in, CParseContext& context);
+    void undef(std::istream& in, CParseContext& context);
+    void ifdef(std::istream& in, CParseContext& context);
+    void ifndef(std::istream& in, CParseContext& context);
+    void else_cmd(std::istream& in, CParseContext& context);
+    void endif(std::istream& in, CParseContext& context);
+  };
+}
+
+#endif

--- a/rychkov.mihail/F0/preprocessor.hpp
+++ b/rychkov.mihail/F0/preprocessor.hpp
@@ -5,10 +5,10 @@
 #include <iosfwd>
 #include <string>
 #include <vector>
-#include <set>
-#include <map>
 #include <memory>
 #include <stack.hpp>
+#include <set.hpp>
+#include <map.hpp>
 
 #include "log.hpp"
 #include "content.hpp"
@@ -22,8 +22,8 @@ namespace rychkov
   public:
     std::vector< std::string > include_paths;
     std::unique_ptr< Lexer > next;
-    std::set< Macro, NameCompare > macros;
-    std::multiset< Macro, NameCompare > legacy_macros;
+    Set< Macro, NameCompare > macros;
+    MultiSet< Macro, NameCompare > legacy_macros;
 
     Preprocessor();
     Preprocessor(std::unique_ptr< Lexer > lexer, std::vector< std::string > search_dirs);
@@ -55,7 +55,7 @@ namespace rychkov
       SKIP_ELSE
     };
 
-    std::map< std::string, void(Preprocessor::*)(std::istream&, CParseContext&) > directives_ = {
+    Map< std::string, void(Preprocessor::*)(std::istream&, CParseContext&) > directives_ = {
           {"include", &rychkov::Preprocessor::include},
           {"define", &rychkov::Preprocessor::define},
           {"pragma", &rychkov::Preprocessor::pragma},

--- a/rychkov.mihail/F0/preprocessor.hpp
+++ b/rychkov.mihail/F0/preprocessor.hpp
@@ -5,10 +5,10 @@
 #include <iosfwd>
 #include <string>
 #include <vector>
-#include <stack>
 #include <set>
 #include <map>
 #include <memory>
+#include <stack.hpp>
 
 #include "log.hpp"
 #include "content.hpp"
@@ -55,7 +55,7 @@ namespace rychkov
       SKIP_ELSE
     };
 
-    const std::map< std::string, void(Preprocessor::*)(std::istream&, CParseContext&) > directives_ = {
+    std::map< std::string, void(Preprocessor::*)(std::istream&, CParseContext&) > directives_ = {
           {"include", &rychkov::Preprocessor::include},
           {"define", &rychkov::Preprocessor::define},
           {"pragma", &rychkov::Preprocessor::pragma},
@@ -77,7 +77,7 @@ namespace rychkov
     std::vector< std::string > expansion_list_;
 
     std::string buf_;
-    std::stack< IfStage > conditional_pairs_;
+    rychkov::Stack< IfStage > conditional_pairs_;
 
     static void remove_whitespaces(std::string& str);
     bool skip_all() const noexcept;

--- a/rychkov.mihail/F0/preprocessor_commands.cpp
+++ b/rychkov.mihail/F0/preprocessor_commands.cpp
@@ -1,0 +1,181 @@
+#include "preprocessor.hpp"
+
+#include <iostream>
+#include <fstream>
+#include <utility>
+#include <cctype>
+#include <parser.hpp>
+
+void rychkov::Preprocessor::include(std::istream& in, CParseContext& context)
+{
+  char quote = '\0';
+  if (!(in >> std::ws >> quote))
+  {
+    log(context, "no filename");
+    return;
+  }
+  std::string filename;
+  if ((quote != '"') && (quote != '<'))
+  {
+    log(context, "wrong quotes");
+    return;
+  }
+  std::getline(in, filename, (quote == '"' ? '"' : '>'));
+  if (in.eof())
+  {
+    log(context, "missing end quote");
+    return;
+  }
+  if (!(in >> std::ws).eof())
+  {
+    log(context, "text after filename");
+    return;
+  }
+
+  buf_.clear();
+  std::ifstream file;
+  if (quote == '"')
+  {
+    file.open(filename);
+  }
+  else
+  {
+    for (const std::string& base_path: include_paths)
+    {
+      file.open(base_path + '/' + filename);
+      if (file.is_open())
+      {
+        filename = base_path + '/' + filename;
+        break;
+      }
+    }
+  }
+  if (!file)
+  {
+    log(context, "failed to open file");
+    return;
+  }
+  CParseContext file_context = {context.out, context.err, filename, &context};
+  parse(file_context, file, false);
+  context.nerrors += file_context.nerrors;
+}
+void rychkov::Preprocessor::define(std::istream& in, CParseContext& context)
+{
+  Macro macro = {get_name(in >> std::ws)};
+  if (macro.name.empty())
+  {
+    log(context, "macro must have name");
+    return;
+  }
+  if (std::isdigit(macro.name.front()))
+  {
+    log(context, "macro name cannot start with digit");
+    return;
+  }
+  if (in.peek() == '(')
+  {
+    in.ignore(1);
+    macro.func_style = true;
+    while (true)
+    {
+      if ((in >> std::ws).peek() == ')')
+      {
+        in.ignore(1);
+        break;
+      }
+      std::string name = get_name(in);
+      if (name.empty())
+      {
+        log(context, "macro parameter must have name");
+        return;
+      }
+      if (std::isdigit(name.front()))
+      {
+        log(context, "macro parameter name cannot start with digit (\"" + name + "\")");
+        return;
+      }
+      macro.parameters.push_back(std::move(name));
+      if ((in >> std::ws).peek() == ',')
+      {
+        in.ignore(1);
+      }
+    }
+  }
+  std::getline(in >> std::ws, macro.body);
+  remove_whitespaces(macro.body);
+  macros.erase(macro);
+  macros.insert(std::move(macro));
+}
+void rychkov::Preprocessor::pragma(std::istream&, CParseContext& context)
+{
+  log(context, "#pragma is unsupported");
+}
+void rychkov::Preprocessor::undef(std::istream& in, CParseContext& context)
+{
+  std::string name;
+  if (eol(in >> std::ws >> name) && !name.empty())
+  {
+    decltype(macros)::iterator temp = macros.find(name);
+    if (temp != macros.end())
+    {
+      legacy_macros.insert(*temp);
+      macros.erase(temp);
+    }
+    return;
+  }
+  log(context, "wrong #undef format");
+}
+void rychkov::Preprocessor::ifdef(std::istream& in, CParseContext& context)
+{
+  std::string name;
+  if (!(in >> std::ws >> name) || !eol(in))
+  {
+    log(context, "wrong macro name format");
+    return;
+  }
+  conditional_pairs_.push(macros.find(name) == macros.end() ? WAIT_ELSE : IF_BODY);
+}
+void rychkov::Preprocessor::ifndef(std::istream& in, CParseContext& context)
+{
+  std::string name;
+  if (!(in >> std::ws >> name) || !eol(in))
+  {
+    log(context, "wrong macro name format");
+    return;
+  }
+  conditional_pairs_.push(macros.find(name) != macros.end() ? WAIT_ELSE : IF_BODY);
+}
+void rychkov::Preprocessor::else_cmd(std::istream& in, CParseContext& context)
+{
+  if (!eol(in))
+  {
+    log(context, "unexpected symbols after #else");
+  }
+  else if (conditional_pairs_.empty())
+  {
+    log(context, "#else must be paired with #if directive");
+  }
+  else if ((conditional_pairs_.top() == ELSE_BODY) || (conditional_pairs_.top() == SKIP_ELSE))
+  {
+    log(context, "#else duplicated");
+  }
+  else
+  {
+    conditional_pairs_.top() = (conditional_pairs_.top() == IF_BODY ? SKIP_ELSE : ELSE_BODY);
+  }
+}
+void rychkov::Preprocessor::endif(std::istream& in, CParseContext& context)
+{
+  if (!eol(in))
+  {
+    log(context, "unexpected symbols after #endif");
+  }
+  else if (conditional_pairs_.empty())
+  {
+    log(context, "#endif must be paired with #if directive");
+  }
+  else
+  {
+    conditional_pairs_.pop();
+  }
+}

--- a/rychkov.mihail/F0/preprocessor_stream_parsing.cpp
+++ b/rychkov.mihail/F0/preprocessor_stream_parsing.cpp
@@ -1,0 +1,245 @@
+#include "preprocessor.hpp"
+
+#include <iostream>
+#include <utility>
+#include <algorithm>
+
+void rychkov::Preprocessor::append(CParseContext& context, char c)
+{
+  if (screened_ && (c == '\n'))
+  {
+    screened_ = false;
+    return;
+  }
+  if (!screened_ && (c == '\\'))
+  {
+    screened_ = true;
+    return;
+  }
+  switch (state_)
+  {
+  case SINGLE_LINE_COMMENT:
+    if (c == '\n')
+    {
+      state_ = prev_state_;
+      prev_state_ = NO_STATE;
+      screened_ = false;
+      append(context, '\n');
+      return;
+    }
+    return;
+  case MULTI_LINE_COMMENT:
+    if ((prev_ == '*') && (c == '/'))
+    {
+      state_ = prev_state_;
+      prev_state_ = NO_STATE;
+      prev_ = '\0';
+      screened_ = false;
+      return;
+    }
+    prev_ = c;
+    return;
+  case STRING_LITERAL:
+    if (screened_)
+    {
+      buf_ += '\\';
+      buf_ += c;
+      screened_ = false;
+      return;
+    }
+    if (c == '\n')
+    {
+      log(context, "string literal cannot contain multiple lines");
+      return;
+    }
+    buf_ += c;
+    if (c == '"')
+    {
+      flush_buf(context);
+    }
+    return;
+  case CHAR_LITERAL:
+    if (screened_)
+    {
+      buf_ += '\\';
+      buf_ += c;
+      screened_ = false;
+      return;
+    }
+    if (c == '\n')
+    {
+      log(context, "char literal cannot contain multiple lines");
+      return;
+    }
+    buf_ += c;
+    if (c == '\'')
+    {
+      flush_buf(context);
+    }
+    return;
+  case NAME:
+    if (screened_)
+    {
+      flush_buf(context);
+      append(context, '\\');
+      append(context, c);
+      screened_ = false;
+      return;
+    }
+    if (!std::isalnum(c) && (c != '_'))
+    {
+      flush_buf(context);
+      append(context, c);
+      return;
+    }
+    buf_ += c;
+    return;
+  case NUMBER:
+    if (screened_)
+    {
+      flush_buf(context);
+      append(context, '\\');
+      append(context, c);
+      screened_ = false;
+      return;
+    }
+    if (!std::isalnum(c) && (c != '_') && (c != '.') && (c != '\''))
+    {
+      flush_buf(context);
+      append(context, c);
+      return;
+    }
+    buf_ += c;
+    return;
+  case MACRO_PARAMETERS:
+  case DIRECTIVE:
+  case NO_STATE:
+    if (screened_)
+    {
+      flush(context, '\\');
+      screened_ = false;
+      empty_line_ = false;
+    }
+    if (prev_ == '/')
+    {
+      if (c == '/')
+      {
+        prev_state_ = state_;
+        state_ = SINGLE_LINE_COMMENT;
+        prev_ = '\0';
+        return;
+      }
+      else if (c == '*')
+      {
+        prev_state_ = state_;
+        state_ = MULTI_LINE_COMMENT;
+        prev_ = '\0';
+        return;
+      }
+      flush(context, '/');
+      empty_line_ = false;
+      prev_ = '\0';
+    }
+    if (c == '/')
+    {
+      prev_ = '/';
+      return;
+    }
+    if (empty_line_ && (c == '#'))
+    {
+      prev_state_ = NO_STATE;
+      state_ = DIRECTIVE;
+      return;
+    }
+    if (empty_line_ && !std::isspace(c))
+    {
+      empty_line_ = false;
+    }
+    if (state_ == MACRO_PARAMETERS)
+    {
+      if (c == '(')
+      {
+        parentheses_depth_++;
+        if (parentheses_depth_ == 1)
+        {
+          return;
+        }
+      }
+      if (c == ')')
+      {
+        if (parentheses_depth_ == 0)
+        {
+          log(context, "function-style macro must have call list");
+          return;
+        }
+        parentheses_depth_--;
+        if (parentheses_depth_ == 0)
+        {
+          state_ = prev_state_;
+          prev_state_ = NO_STATE;
+          expanse_macro(context);
+          flush_buf(context);
+          return;
+        }
+      }
+      if ((c == ',') && (parentheses_depth_ == 1))
+      {
+        remove_whitespaces(buf_);
+        expansion_list_.push_back(std::move(buf_));
+        buf_.clear();
+        return;
+      }
+      if (!std::isspace(c) && (parentheses_depth_ == 0))
+      {
+        log(context, "function-style macro must have call list");
+        return;
+      }
+      if ((parentheses_depth_ != 0) && (c == '\n'))
+      {
+        log(context, "function-style macro parameters cannot contain multiple lines");
+        return;
+      }
+    }
+    else if (state_ != DIRECTIVE)
+    {
+      if (std::isalpha(c) || (c == '_'))
+      {
+        buf_ += c;
+        state_ = NAME;
+        return;
+      }
+      if (std::isdigit(c))
+      {
+        buf_ += c;
+        state_ = NUMBER;
+        return;
+      }
+    }
+    if (c == '"')
+    {
+      buf_ += '"';
+      prev_state_ = state_;
+      state_ = STRING_LITERAL;
+      return;
+    }
+    if (c == '\'')
+    {
+      buf_ += '\'';
+      prev_state_ = state_;
+      state_ = CHAR_LITERAL;
+      return;
+    }
+    if (c == '\n')
+    {
+      if (state_ == DIRECTIVE)
+      {
+        flush_buf(context);
+        append(context, '\n');
+        return;
+      }
+      empty_line_ = true;
+    }
+    flush(context, c);
+    return;
+  }
+}

--- a/rychkov.mihail/F0/preprocessor_stream_parsing.cpp
+++ b/rychkov.mihail/F0/preprocessor_stream_parsing.cpp
@@ -2,7 +2,6 @@
 
 #include <iostream>
 #include <utility>
-#include <algorithm>
 
 void rychkov::Preprocessor::append(CParseContext& context, char c)
 {

--- a/rychkov.mihail/F0/print_content.hpp
+++ b/rychkov.mihail/F0/print_content.hpp
@@ -1,0 +1,60 @@
+#ifndef PRINT_CONTENT_HPP
+#define PRINT_CONTENT_HPP
+
+#include <iosfwd>
+#include <string>
+#include "content.hpp"
+
+namespace rychkov
+{
+  class ContentPrinter
+  {
+  public:
+    std::ostream& out;
+    ContentPrinter(std::ostream& ostream, size_t start_indent = 0);
+
+    void operator()(const std::string& any);
+    void operator()(const Macro& macro);
+    void operator()(const entities::Variable& var);
+    void operator()(const entities::Function& func);
+    void operator()(const entities::Body& body);
+    void operator()(const entities::Statement& statement);
+    void operator()(const entities::Struct& structure);
+    void operator()(const entities::Enum& structure);
+    void operator()(const entities::Union& structure);
+    void operator()(const entities::Alias& alias);
+    void operator()(const entities::Declaration& decl);
+
+    void operator()(const entities::Literal& literal);
+    void operator()(const entities::CastOperation& cast);
+
+    void operator()(const DynMemWrapper< entities::Expression >& root);
+    void operator()(const entities::Expression& root);
+    void operator()(const entities::Expression::operand& operand);
+
+    std::ostream& indent();
+    void print_empty();
+  private:
+    size_t indent_;
+  };
+
+  namespace details
+  {
+    std::ostream& print_left_parenthesis(std::ostream& out, const typing::Type& parent);
+    std::ostream& print_right_parenthesis(std::ostream& out, const typing::Type& parent);
+  }
+  namespace typing
+  {
+    std::ostream& print_left(std::ostream& out, const Type& type);
+    std::ostream& print_right(std::ostream& out, const Type& type);
+    std::ostream& operator<<(std::ostream& out, const Type& type);
+  }
+  namespace entities
+  {
+    std::ostream& operator<<(std::ostream& out, const Variable& var);
+    std::ostream& operator<<(std::ostream& out, const Function& func);
+    std::ostream& operator<<(std::ostream& out, const Literal& literal);
+  }
+}
+
+#endif

--- a/rychkov.mihail/F0/print_entities.cpp
+++ b/rychkov.mihail/F0/print_entities.cpp
@@ -1,0 +1,203 @@
+#include "print_content.hpp"
+
+#include <iostream>
+#include <algorithm>
+
+std::ostream& rychkov::entities::operator<<(std::ostream& out, const Variable& var)
+{
+  typing::print_left(out, var.type);
+  out << ' ' << var.name;
+  typing::print_right(out, var.type);
+  return out;
+}
+std::ostream& rychkov::entities::operator<<(std::ostream& out, const Function& func)
+{
+  typing::print_left(out, func.type);
+  out << ' ' << func.name;
+  out << '(';
+  char comma[3] = "\0 ";
+  for (size_t i = 0; i < func.type.function_parameters.size(); i++)
+  {
+    out << comma;
+    typing::print_left(out, func.type.function_parameters[i]);
+    out << ' ' << func.parameters[i];
+    print_right(out, func.type.function_parameters[i]);
+    comma[0] = ',';
+  }
+  out << ')';
+  details::print_right_parenthesis(out, func.type);
+  print_right(out, *func.type.base);
+  return out;
+}
+std::ostream& rychkov::entities::operator<<(std::ostream& out, const Literal& literal)
+{
+  switch (literal.type)
+  {
+  case entities::Literal::String:
+    out << '"' << literal.literal << '"';
+    break;
+  case entities::Literal::Char:
+    out << '\'' << literal.literal << '\'';
+    break;
+  case entities::Literal::Number:
+    out << literal.literal;
+    break;
+  }
+  return out << literal.suffix;
+}
+
+rychkov::ContentPrinter::ContentPrinter(std::ostream& ostream, size_t start_indent):
+  out(ostream),
+  indent_(start_indent)
+{}
+std::ostream& rychkov::ContentPrinter::indent()
+{
+  return out << std::string(indent_, '\t');
+}
+void rychkov::ContentPrinter::print_empty()
+{
+  indent() << "* [EMPTY]\n";
+}
+
+void rychkov::ContentPrinter::operator()(const std::string& any)
+{
+  indent() << "* " << any << '\n';
+}
+void rychkov::ContentPrinter::operator()(const Macro& macro)
+{
+  indent() << "* [macro] " << macro.name;
+  if (macro.func_style)
+  {
+    out << '(';
+    char comma[3] = "\0\0";
+    for (const std::string& param: macro.parameters)
+    {
+      out << comma << param;
+      comma[0] = ',';
+      comma[1] = ' ';
+    }
+    out << ')';
+  }
+  out << ' ' << macro.body << '\n';
+}
+void rychkov::ContentPrinter::operator()(const entities::Variable& var)
+{
+  indent() << "* [variable] " << var << '\n';
+}
+void rychkov::ContentPrinter::operator()(const entities::Function& func)
+{
+  indent() << "* [function] " << func << '\n';
+}
+void rychkov::ContentPrinter::operator()(const entities::Body& body)
+{
+  if (body.data.empty())
+  {
+    indent() << "{}\n";
+  }
+  else
+  {
+    indent() << "{\n";
+    indent_++;
+    for (const entities::Expression& i: body.data)
+    {
+      operator()(i);
+    }
+    indent_--;
+    indent() << "}\n";
+  }
+}
+void rychkov::ContentPrinter::operator()(const entities::Statement& statement)
+{
+  const char* names[] = {"if", "else", "for", "while", "do", "return", "do-while"};
+  indent() << "* [statement] " << names[statement.type] << '\n';
+  if ((statement.type != entities::Statement::DO) && (statement.type != entities::Statement::RETURN)
+      && (statement.type != entities::Statement::ELSE))
+  {
+    indent() << "<conditions>:\n";
+    indent_++;
+    for (size_t i = 0; i < statement.conditions.size(); i++)
+    {
+      operator()(statement.conditions[i]);
+    }
+    indent_--;
+  }
+}
+void rychkov::ContentPrinter::operator()(const entities::Struct& structure)
+{
+  indent() << "* [struct] " << structure.name << '\n';
+  indent_++;
+  for (const entities::Variable& i: structure.fields)
+  {
+    indent() << "* [field] " << i << '\n';
+  }
+  indent_--;
+}
+void rychkov::ContentPrinter::operator()(const entities::Enum& structure)
+{
+  indent() << "* [enum] " << structure.name << '\n';
+  indent_++;
+  for (const std::pair< const std::string, int >& i: structure.fields)
+  {
+    indent() << i.first << " = " << i.second << '\n';
+  }
+  indent_--;
+}
+void rychkov::ContentPrinter::operator()(const entities::Union& structure)
+{
+  indent() << "* [union] " << structure.name << '\n';
+  indent_++;
+  for (const entities::Variable& i: structure.fields)
+  {
+    indent() << "* [variant] " << i << '\n';
+  }
+  indent_--;
+}
+void rychkov::ContentPrinter::operator()(const entities::Alias& alias)
+{
+  indent() << "* [typedef] ";
+  print_left(out, alias.type);
+  out << ' ' << alias.name;
+  print_right(out, alias.type);
+  out << '\n';
+}
+void rychkov::ContentPrinter::operator()(const entities::Declaration& decl)
+{
+  if (decl.scope == entities::EXTERN)
+  {
+    indent() << "* [extern declaration]\n";
+  }
+  else if (decl.scope == entities::STATIC)
+  {
+    indent() << "* [static declaration]\n";
+  }
+  else
+  {
+    indent() << "* [declaration]\n";
+  }
+  indent() << "<object>:\n";
+  indent_++;
+  boost::variant2::visit(*this, decl.data);
+  indent_--;
+  if (decl.value != nullptr)
+  {
+    indent() << "<definition>:\n";
+    indent_++;
+    operator()(*decl.value);
+    indent_--;
+  }
+}
+void rychkov::ContentPrinter::operator()(const entities::Literal& literal)
+{
+  indent() << "* [literal]\n";
+  indent() << "<object> " << literal << '\n';
+  indent() << "<type>   " << literal.result_type << '\n';
+}
+void rychkov::ContentPrinter::operator()(const entities::CastOperation& cast)
+{
+  indent() << (cast.is_explicit ? "[explicit cast]\n" : "[implicit cast]\n");
+  indent() << "<to>   " << cast.to << '\n';
+  indent() << "<object>:\n";
+  indent_++;
+  operator()(cast.expr);
+  indent_--;
+}

--- a/rychkov.mihail/F0/print_entities.cpp
+++ b/rychkov.mihail/F0/print_entities.cpp
@@ -1,7 +1,6 @@
 #include "print_content.hpp"
 
 #include <iostream>
-#include <algorithm>
 
 std::ostream& rychkov::entities::operator<<(std::ostream& out, const Variable& var)
 {

--- a/rychkov.mihail/F0/print_entities.cpp
+++ b/rychkov.mihail/F0/print_entities.cpp
@@ -176,7 +176,7 @@ void rychkov::ContentPrinter::operator()(const entities::Declaration& decl)
   }
   indent() << "<object>:\n";
   indent_++;
-  boost::variant2::visit(*this, decl.data);
+  visit(*this, decl.data);
   indent_--;
   if (decl.value != nullptr)
   {

--- a/rychkov.mihail/F0/print_expression.cpp
+++ b/rychkov.mihail/F0/print_expression.cpp
@@ -1,0 +1,66 @@
+#include "print_content.hpp"
+
+#include <iostream>
+
+void rychkov::ContentPrinter::operator()(const DynMemWrapper< entities::Expression >& expr)
+{
+  operator()(*expr);
+}
+void rychkov::ContentPrinter::operator()(const entities::Expression::operand& oper)
+{
+  boost::variant2::visit(*this, oper);
+}
+void rychkov::ContentPrinter::operator()(const entities::Expression& expr)
+{
+  if (expr.operation == nullptr)
+  {
+    if (expr.operands.empty())
+    {
+      print_empty();
+      return;
+    }
+    operator()(expr.operands[0]);
+    return;
+  }
+  size_t oper_size = expr.operation->type;
+  if (expr.operation->type == Operator::UNARY)
+  {
+    indent() << "* [unary] operator" << expr.operation->token;
+    out << (expr.operation->right_align ? " <prefix form>\n" : " <suffix form>\n");
+  }
+  else if (expr.operation->type == Operator::BINARY)
+  {
+    indent() << "* [binary] operator" << expr.operation->token << '\n';
+  }
+  else if (expr.operation->type == Operator::TERNARY)
+  {
+    indent() << "* [ternary] operator" << expr.operation->token << '\n';
+  }
+  else
+  {
+    indent() << "* [multi] operator" << expr.operation->token << " - size=" << expr.operands.size() << '\n';
+    oper_size = expr.operands.size();
+  }
+  if (expr.result_type.ready())
+  {
+    indent() << (entities::is_lvalue(&expr) ? "<type(l)> " : "<type> ") << expr.result_type << '\n';
+  }
+  else
+  {
+    indent() << "<type> [NONE]\n";
+  }
+  indent() << "<operands>:\n";
+  indent_++;
+  for (size_t i = 0; i < oper_size; i++)
+  {
+    if (i < expr.operands.size())
+    {
+      operator()(expr.operands[i]);
+    }
+    else
+    {
+      print_empty();
+    }
+  }
+  indent_--;
+}

--- a/rychkov.mihail/F0/print_expression.cpp
+++ b/rychkov.mihail/F0/print_expression.cpp
@@ -8,7 +8,7 @@ void rychkov::ContentPrinter::operator()(const DynMemWrapper< entities::Expressi
 }
 void rychkov::ContentPrinter::operator()(const entities::Expression::operand& oper)
 {
-  boost::variant2::visit(*this, oper);
+  visit(*this, oper);
 }
 void rychkov::ContentPrinter::operator()(const entities::Expression& expr)
 {

--- a/rychkov.mihail/F0/print_type.cpp
+++ b/rychkov.mihail/F0/print_type.cpp
@@ -1,0 +1,152 @@
+#include "print_content.hpp"
+
+#include <iostream>
+
+std::ostream& rychkov::details::print_left_parenthesis(std::ostream& out, const typing::Type& parent)
+{
+  if (parent.base == nullptr)
+  {
+    return out;
+  }
+  if ((parent.category == typing::ARRAY) && (parent.base->category == typing::ARRAY))
+  {
+    return out;
+  }
+  if ((parent.base->category == typing::FUNCTION) || (parent.base->category == typing::ARRAY))
+  {
+    out << '(';
+  }
+  return out;
+}
+std::ostream& rychkov::details::print_right_parenthesis(std::ostream& out, const typing::Type& parent)
+{
+  if (parent.base == nullptr)
+  {
+    return out;
+  }
+  if ((parent.category == typing::ARRAY) && (parent.base->category == typing::ARRAY))
+  {
+    return out;
+  }
+  if ((parent.base->category == typing::FUNCTION) || (parent.base->category == typing::ARRAY))
+  {
+    out << ')';
+  }
+  return out;
+}
+std::ostream& rychkov::typing::print_left(std::ostream& out, const typing::Type& type)
+{
+  if (type.base != nullptr)
+  {
+    print_left(out, *type.base);
+  }
+  switch (type.category)
+  {
+  case typing::ENUM:
+  case typing::STRUCT:
+    out << type.name;
+    break;
+  case typing::BASIC:
+    if (type.is_signed)
+    {
+      out << "signed ";
+    }
+    if (type.is_unsigned)
+    {
+      out << "unsigned ";
+    }
+    switch (type.length_category)
+    {
+    case typing::SHORT:
+      out << "short ";
+      break;
+    case typing::LONG:
+      out << "long ";
+      break;
+    case typing::LONG_LONG:
+      out << "long long ";
+      break;
+    default:
+      break;
+    }
+    out << type.name;
+    if (type.is_const)
+    {
+      out << " const";
+    }
+    if (type.is_volatile)
+    {
+      out << " volatile";
+    }
+    break;
+  case typing::POINTER:
+    details::print_left_parenthesis(out, type);
+    out << '*';
+    if (type.is_const)
+    {
+      out << " const";
+    }
+    if (type.is_volatile)
+    {
+      out << " volatile";
+    }
+    break;
+  case typing::ARRAY:
+    details::print_left_parenthesis(out, type);
+    break;
+  case typing::COMBINATION:
+    if (type.is_const)
+    {
+      out << " const";
+    }
+    if (type.is_volatile)
+    {
+      out << " volatile";
+    }
+    break;
+  case typing::FUNCTION:
+    break;
+  }
+  return out;
+}
+std::ostream& rychkov::typing::print_right(std::ostream& out, const typing::Type& type)
+{
+  if (type.category == typing::FUNCTION)
+  {
+    out << '(';
+    char comma[3] = "\0\0";
+    for (const typing::Type& i: type.function_parameters)
+    {
+      out << comma << i;
+      comma[0] = ',';
+      comma[1] = ' ';
+    }
+    out << ')';
+    details::print_right_parenthesis(out, type);
+  }
+  else if (type.category == typing::POINTER)
+  {
+    details::print_right_parenthesis(out, type);
+  }
+  else if (type.category == typing::ARRAY)
+  {
+    out << '[';
+    if (type.array_has_length)
+    {
+      out << type.array_length;
+    }
+    out << ']';
+    details::print_right_parenthesis(out, type);
+  }
+  if (type.base != nullptr)
+  {
+    print_right(out, *type.base);
+  }
+  return out;
+}
+std::ostream& rychkov::typing::operator<<(std::ostream& out, const typing::Type& type)
+{
+  print_left(out, type);
+  print_right(out, type);
+  return out;
+}

--- a/rychkov.mihail/F0/type_parse_char.cpp
+++ b/rychkov.mihail/F0/type_parse_char.cpp
@@ -1,0 +1,175 @@
+#include "type_parser.hpp"
+
+#include <utility>
+#include <map>
+
+void rychkov::TypeParser::append(CParseContext& context, char c)
+{
+  static const std::map< char, void(TypeParser::*)(CParseContext&) > dispatch_map = {
+        {'*', &TypeParser::append_asterisk},
+        {'[', &TypeParser::append_open_bracket},
+        {']', &TypeParser::append_close_bracket},
+        {'(', &TypeParser::append_open_parenthesis},
+        {')', &TypeParser::append_close_parenthesis},
+        {',', &TypeParser::append_comma}
+      };
+
+  decltype(dispatch_map)::const_iterator found = dispatch_map.find(c);
+  if (found != dispatch_map.cend())
+  {
+    (this->*(found->second))(context);
+    return;
+  }
+  log(context, "unknown symbol in type declaration");
+}
+void rychkov::TypeParser::append_asterisk(CParseContext& context)
+{
+  if (stack_.empty() || stack_.top().right_allign)
+  {
+    log(context, "pointer cannot be applied here");
+    return;
+  }
+  if (!stack_.top().data->empty())
+  {
+    move_up();
+  }
+  stack_.top().data->category = typing::POINTER;
+}
+void rychkov::TypeParser::append_open_bracket(CParseContext& context)
+{
+  if (stack_.top().data->empty() || stack_.top().bracket_opened
+      || (stack_.top().data->category == typing::FUNCTION))
+  {
+    log(context, "array cannot be applied here");
+    return;
+  }
+  typing::Type* old = move_up();
+  stack_.top().data->category = typing::ARRAY;
+  if (old->category == typing::ARRAY)
+  {
+    stack_.top().data->array_has_length = old->array_has_length;
+    stack_.top().data->array_length = old->array_length;
+    old->array_has_length = false;
+    old->array_length = 0;
+    stack_.top().data = old;
+    stack_.top().array_must_have_size = true;
+  }
+  stack_.top().bracket_opened = true;
+  stack_.top().right_allign = true;
+}
+void rychkov::TypeParser::append_close_bracket(CParseContext& context)
+{
+  if (stack_.empty() || !stack_.top().bracket_opened)
+  {
+    log(context, "found unpaired ']'");
+    return;
+  }
+  if (stack_.top().array_must_have_size && !stack_.top().data->array_has_length)
+  {
+    log(context, "array cannot be abstract here");
+    return;
+  }
+  stack_.top().bracket_opened = false;
+}
+void rychkov::TypeParser::append_open_parenthesis(CParseContext& context)
+{
+  if (stack_.top().data->empty())
+  {
+    log(context, "type cannot starts with '('");
+    return;
+  }
+  if (stack_.top().right_allign)
+  {
+    if ((stack_.top().data->category == typing::ARRAY)
+        || (stack_.top().data->category == typing::FUNCTION))
+    {
+      log(context, "function parentheses cannot be applied here");
+      return;
+    }
+    if (!stack_.top().data->empty())
+    {
+      move_up();
+    }
+    stack_.top().data->category = typing::FUNCTION;
+    stack_.top().data->function_parameters.emplace_back();
+    stack_.push({&stack_.top().data->function_parameters.back()});
+    stack_.top().is_function_paremeter = true;
+    if (can_be_named_param(stack_.top().data))
+    {
+      parameters_.emplace_back();
+    }
+    return;
+  }
+  typing::Type* old = move_up();
+  std::swap(old, stack_.top().data);
+  stack_.push({old});
+  stack_.top().parenthesis_opened = true;
+}
+void rychkov::TypeParser::append_close_parenthesis(CParseContext& context)
+{
+  if (stack_.size() <= 1)
+  {
+    log(context, "found unpaired ')'");
+    return;
+  }
+  if (stack_.top().is_function_paremeter)
+  {
+    if (stack_.top().data->empty() && (stack_.top().data->base == nullptr))
+    {
+      stack_.pop();
+      if (stack_.top().data->function_parameters.size() == 1)
+      {
+        if (can_be_named_param(&stack_.top().data->function_parameters[0]))
+        {
+          parameters_.clear();
+        }
+        stack_.top().data->function_parameters.clear();
+        return;
+      }
+      log(context, "function parameter following after ',' cannot be empty");
+      return;
+    }
+    else if (!stack_.top().data->ready())
+    {
+      log(context, "function parameter started but not finished");
+      return;
+    }
+    stack_.pop();
+    return;
+  }
+  if (stack_.top().bracket_opened)
+  {
+    log(context, "')' cannot follow '['");
+    return;
+  }
+  if (stack_.top().data->empty())
+  {
+    decltype(typing::Type::base) temp = std::move(stack_.top().data->base);
+    *stack_.top().data = std::move(*temp);
+
+    typing::Type* old = stack_.top().data;
+    stack_.pop();
+    stack_.top().data = old;
+    stack_.top().right_allign = true;
+    return;
+  }
+  stack_.pop();
+  stack_.top().right_allign = true;
+}
+void rychkov::TypeParser::append_comma(CParseContext& context)
+{
+  if ((stack_.size() <= 1) || !stack_.top().is_function_paremeter || !stack_.top().data->ready())
+  {
+    log(context, "',' cannot be applied here");
+    return;
+  }
+  remove_combination(*stack_.top().data);
+  stack_.pop();
+  stack_.top().data->function_parameters.emplace_back();
+  stack_.push({&stack_.top().data->function_parameters.back()});
+  stack_.top().is_function_paremeter = true;
+  if (can_be_named_param(stack_.top().data))
+  {
+    parameters_.emplace_back();
+  }
+}

--- a/rychkov.mihail/F0/type_parse_char.cpp
+++ b/rychkov.mihail/F0/type_parse_char.cpp
@@ -1,11 +1,11 @@
 #include "type_parser.hpp"
 
 #include <utility>
-#include <map>
+#include <map.hpp>
 
 void rychkov::TypeParser::append(CParseContext& context, char c)
 {
-  static const std::map< char, void(TypeParser::*)(CParseContext&) > dispatch_map = {
+  static const Map< char, void(TypeParser::*)(CParseContext&) > dispatch_map = {
         {'*', &TypeParser::append_asterisk},
         {'[', &TypeParser::append_open_bracket},
         {']', &TypeParser::append_close_bracket},

--- a/rychkov.mihail/F0/type_parse_name.cpp
+++ b/rychkov.mihail/F0/type_parse_name.cpp
@@ -1,0 +1,72 @@
+#include "type_parser.hpp"
+
+#include <utility>
+
+void rychkov::TypeParser::append(CParseContext& context, std::string name)
+{
+  if (stack_.top().data != &combined_)
+  {
+    if (can_be_named_param(stack_.top().data))
+    {
+      parameters_.back() = std::move(name);
+      return;
+    }
+    log(context, "name \"" + name + "\" cannot be placed here");
+    return;
+  }
+  if (!var_name_.empty())
+  {
+    log(context, "name repeated");
+    return;
+  }
+  var_name_ = std::move(name);
+  stack_.top().right_allign = true;
+}
+void rychkov::TypeParser::append_const(CParseContext& context)
+{
+  if (stack_.empty())
+  {
+    combined_ = {{}, typing::COMBINATION};
+    combined_.is_const = true;
+    stack_.push({&combined_});
+  }
+  else if (stack_.top().right_allign)
+  {
+    log(context, "const cannot be applied here");
+  }
+  else if (stack_.top().data->is_const)
+  {
+    log(context, "const repeated");
+  }
+  else
+  {
+    stack_.top().data->is_const = true;
+  }
+}
+void rychkov::TypeParser::append_volatile(CParseContext& context)
+{
+  if (stack_.empty())
+  {
+    combined_ = {{}, typing::COMBINATION};
+    combined_.is_volatile = true;
+    stack_.push({&combined_});
+  }
+  if (stack_.top().right_allign)
+  {
+    log(context, "volatile cannot be applied here");
+  }
+  if (stack_.top().data->is_volatile)
+  {
+    log(context, "volatile repeated");
+  }
+  else
+  {
+    stack_.top().data->is_volatile = true;
+  }
+}
+void rychkov::TypeParser::append_signed(CParseContext&)
+{}
+void rychkov::TypeParser::append_unsigned(CParseContext&)
+{}
+void rychkov::TypeParser::append_long(CParseContext&)
+{}

--- a/rychkov.mihail/F0/type_parser.cpp
+++ b/rychkov.mihail/F0/type_parser.cpp
@@ -1,0 +1,112 @@
+#include "type_parser.hpp"
+
+#include <utility>
+
+void rychkov::TypeParser::remove_combination(typing::Type& type)
+{
+  if (type.category == typing::COMBINATION)
+  {
+    DynMemWrapper< typing::Type > temp = std::move(type.base);
+    temp->is_const = type.is_const || temp->is_const;
+    temp->is_volatile = type.is_volatile || temp->is_volatile;
+    type = std::move(*temp);
+  }
+}
+rychkov::typing::Type* rychkov::TypeParser::move_up()
+{
+  remove_combination(*stack_.top().data);
+  typing::Type* old = new typing::Type{std::move(*stack_.top().data)};
+  *stack_.top().data = {{}, typing::COMBINATION, old};
+  return old;
+}
+bool rychkov::TypeParser::can_be_named_param(typing::Type* type_p)
+{
+  return is_function() && !combined_.function_parameters.empty()
+      && (&combined_.function_parameters.back() == type_p);
+}
+bool rychkov::TypeParser::empty() const noexcept
+{
+  return stack_.empty();
+}
+bool rychkov::TypeParser::ready() const noexcept
+{
+  return (stack_.size() == 1) && !stack_.top().bracket_opened && !stack_.top().parenthesis_opened;
+}
+bool rychkov::TypeParser::is_type() const noexcept
+{
+  return !empty() && var_name_.empty();
+}
+bool rychkov::TypeParser::is_function() const noexcept
+{
+  return !empty() && (combined_.category == typing::FUNCTION);
+}
+
+void rychkov::TypeParser::prepare()
+{
+  remove_combination(combined_);
+}
+rychkov::typing::Type rychkov::TypeParser::type() const
+{
+  remove_combination(*stack_.top().data);
+  return combined_;
+}
+rychkov::entities::Variable rychkov::TypeParser::variable() const
+{
+  remove_combination(*stack_.top().data);
+  return {combined_, var_name_};
+}
+rychkov::entities::Function rychkov::TypeParser::function() const
+{
+  remove_combination(*stack_.top().data);
+  return {combined_, var_name_, parameters_};
+}
+std::string rychkov::TypeParser::name() const
+{
+  return var_name_;
+}
+void rychkov::TypeParser::clear()
+{
+  combined_ = {};
+  stack_ = {};
+  var_name_.clear();
+  parameters_.clear();
+}
+
+void rychkov::TypeParser::append(CParseContext& context, unsigned long long numeric_literal)
+{
+  if (stack_.empty() || !stack_.top().bracket_opened)
+  {
+    log(context, "number cannot be parsed here");
+    return;
+  }
+  stack_.top().data->array_has_length = true;
+  stack_.top().data->array_length = numeric_literal;
+}
+void rychkov::TypeParser::append(CParseContext& context, typing::Type base_type)
+{
+  if (stack_.empty())
+  {
+    combined_ = std::move(base_type);
+    stack_.push({&combined_});
+    return;
+  }
+  if (!stack_.top().data->name.empty() || stack_.top().data->base != nullptr)
+  {
+    log(context, "types cannot be merged here");
+    return;
+  }
+  if ((base_type.category == typing::ARRAY) || (base_type.category == typing::FUNCTION))
+  {
+    if (stack_.top().data->is_const || stack_.top().data->is_volatile)
+    {
+      log(context, "const cannot be applied to array or function");
+      return;
+    }
+  }
+  if ((base_type.category != typing::BASIC) && (stack_.top().data->is_signed || stack_.top().data->is_unsigned))
+  {
+    log(context, "signed or unsigned cannot be applied not to integer type");
+    return;
+  }
+  stack_.top().data->base = std::move(base_type);
+}

--- a/rychkov.mihail/F0/type_parser.hpp
+++ b/rychkov.mihail/F0/type_parser.hpp
@@ -1,0 +1,65 @@
+#ifndef TYPE_PARSER_HPP
+#define TYPE_PARSER_HPP
+
+#include <string>
+#include <stack>
+#include "log.hpp"
+#include "content.hpp"
+
+namespace rychkov
+{
+  class TypeParser
+  {
+  public:
+    bool empty() const noexcept;
+    bool ready() const noexcept;
+    bool is_type() const noexcept;
+    bool is_function() const noexcept;
+
+    void prepare();
+    typing::Type type() const;
+    entities::Variable variable() const;
+    entities::Function function() const;
+    std::string name() const;
+    void clear();
+
+    void append(CParseContext& context, char c);
+    void append(CParseContext& context, std::string name);
+    void append(CParseContext& context, unsigned long long numeric_literal);
+    void append(CParseContext& context, typing::Type base_type);
+
+    void append_const(CParseContext& context);
+    void append_volatile(CParseContext& context);
+    void append_signed(CParseContext& context);
+    void append_unsigned(CParseContext& context);
+    void append_long(CParseContext& context);
+
+  private:
+    struct ParseCell
+    {
+      typing::Type* data;
+      bool right_allign = false;
+      bool bracket_opened = false;
+      bool parenthesis_opened = false;
+      bool array_must_have_size = false;
+      bool is_function_paremeter = false;
+    };
+    typing::Type combined_;
+    std::stack< ParseCell > stack_;
+    std::string var_name_;
+    std::vector< std::string > parameters_;
+
+    void append_asterisk(CParseContext& context);
+    void append_open_bracket(CParseContext& context);
+    void append_close_bracket(CParseContext& context);
+    void append_open_parenthesis(CParseContext& context);
+    void append_close_parenthesis(CParseContext& context);
+    void append_comma(CParseContext& context);
+
+    static void remove_combination(typing::Type& type);
+    typing::Type* move_up();
+    bool can_be_named_param(typing::Type* type_p);
+  };
+}
+
+#endif

--- a/rychkov.mihail/F0/type_parser.hpp
+++ b/rychkov.mihail/F0/type_parser.hpp
@@ -2,7 +2,7 @@
 #define TYPE_PARSER_HPP
 
 #include <string>
-#include <stack>
+#include <stack.hpp>
 #include "log.hpp"
 #include "content.hpp"
 
@@ -45,7 +45,7 @@ namespace rychkov
       bool is_function_paremeter = false;
     };
     typing::Type combined_;
-    std::stack< ParseCell > stack_;
+    rychkov::Stack< ParseCell > stack_;
     std::string var_name_;
     std::vector< std::string > parameters_;
 

--- a/rychkov.mihail/common/algorithm.hpp
+++ b/rychkov.mihail/common/algorithm.hpp
@@ -1,0 +1,131 @@
+#ifndef ALGORITHM_HPP
+#define ALGORITHM_HPP
+
+#include <iterator>
+#include <functional>
+#include "functional.hpp"
+
+namespace rychkov
+{
+  template< class InputIt, class Unary >
+  Unary for_each(InputIt from, InputIt to, Unary f)
+  {
+    for (; from != to; ++from)
+    {
+      invoke(f, *from);
+    }
+    return f;
+  }
+  template< class InputIt, class Sz, class Unary >
+  Unary for_each_n(InputIt from, Sz n, Unary f)
+  {
+    for (Sz i = 0; i < n; ++from)
+    {
+      invoke(f, *from);
+    }
+    return f;
+  }
+
+  template< class InputIt, class T = typename std::iterator_traits< InputIt >::value_type >
+  InputIt find(InputIt from, InputIt to, const T& value)
+  {
+    for (; from != to; ++from)
+    {
+      if (*from == value)
+      {
+        return from;
+      }
+    }
+    return to;
+  }
+  template< class InputIt, class UnaryPred >
+  InputIt find_if(InputIt from, InputIt to, UnaryPred predicate)
+  {
+    for (; from != to; ++from)
+    {
+      if (invoke_r< bool >(predicate, *from))
+      {
+        return from;
+      }
+    }
+    return to;
+  }
+  template< class InputIt, class UnaryPred >
+  InputIt find_if_not(InputIt from, InputIt to, UnaryPred predicate)
+  {
+    for (; from != to; ++from)
+    {
+      if (!invoke_r< bool >(predicate, *from))
+      {
+        return from;
+      }
+    }
+    return to;
+  }
+
+  template< class FwdIt, class BinaryPred >
+  FwdIt unique(FwdIt from, FwdIt to, BinaryPred predicate)
+  {
+    if (from == to)
+    {
+      return to;
+    }
+    FwdIt result = from;
+    while (++from != to)
+    {
+      if (!invoke_r< bool >(predicate, *result, *from) && (++result != from))
+      {
+        *result = std::move(*from);
+      }
+    }
+    return ++result;
+  }
+  template< class FwdIt >
+  FwdIt unique(FwdIt from, FwdIt to)
+  {
+    return rychkov::unique(from, to, std::equal_to<>{});
+  }
+
+  template< class InputIt, class OutputIt, class UnaryOper >
+  OutputIt transform(InputIt from, InputIt to, OutputIt out, UnaryOper oper)
+  {
+    for (; from != to; ++from, ++out)
+    {
+      *out = invoke(oper, *from);
+    }
+    return out;
+  }
+  template< class InputIt, class OutputIt, class BinaryOper >
+  OutputIt transform(InputIt from, InputIt to, InputIt from2, OutputIt out, BinaryOper oper)
+  {
+    for (; from != to; ++from, ++from2, ++out)
+    {
+      *out = invoke(oper, *from, *from2);
+    }
+    return out;
+  }
+
+  template< class InputIt, class OutputIt >
+  OutputIt copy(InputIt from, InputIt to, OutputIt out)
+  {
+    for (; from != to; ++from, ++out)
+    {
+      *out = *from;
+    }
+    return out;
+  }
+  template< class InputIt, class OutputIt, class UnaryPred >
+  OutputIt copy_if(InputIt from, InputIt to, OutputIt out, UnaryPred predicate)
+  {
+    for (; from != to; ++from, ++out)
+    {
+      if (invoke_r< bool >(predicate, *from))
+      {
+        *out = *from;
+      }
+    }
+    return out;
+  }
+}
+
+#endif

--- a/rychkov.mihail/common/map_base/declaration.hpp
+++ b/rychkov.mihail/common/map_base/declaration.hpp
@@ -258,16 +258,10 @@ namespace rychkov
     std::enable_if_t< IsSet && IsSet2, std::pair< iterator, bool > > emplace_impl
         (const_iterator hint, K1&& key, Args&&... args);
 
-    template< bool IsSet2 = IsSet >
-    bool compare_with_key (std::enable_if_t< !IsSet && !IsSet2, const value_type >& lhs,
-          const key_type& rhs) const;
-    template< bool IsSet2 = IsSet >
-    bool compare_with_key(const key_type& lhs,
-          std::enable_if_t< !IsSet && !IsSet2, const value_type >& rhs) const;
-    template< bool IsSet2 = IsSet >
-    std::enable_if_t< IsSet && IsSet2, bool > compare_with_key(const key_type& lhs, const key_type& rhs) const;
-    template< bool IsSet2 = IsSet >
-    std::enable_if_t< !IsSet && !IsSet2, bool > compare_with_key(const key_type& lhs, const key_type& rhs) const;
+    template< bool IsSet2 = IsSet, class K1 = key_type, class K2 = key_type >
+    std::enable_if_t< IsSet && IsSet2, bool > compare_keys(const K1& lhs, const K2& rhs) const;
+    template< bool IsSet2 = IsSet, class K1 = key_type, class K2 = key_type >
+    std::enable_if_t< !IsSet && !IsSet2, bool > compare_keys(const K1& lhs, const K2& rhs) const;
 
     template< class V = value_type >
     static const key_type& get_key(const V& value);

--- a/rychkov.mihail/common/map_base/erase.hpp
+++ b/rychkov.mihail/common/map_base/erase.hpp
@@ -19,7 +19,7 @@ typename rychkov::MapBase< K, T, C, N, IsSet, IsMulti >::iterator
   {
     const_iterator erased = pos;
     --pos;
-    erased.node_->replace(erased.pointed_, std::move(*pos));
+    erased.node_->replace(erased.pointed_, std::move(pos.node_->operator[](pos.pointed_)));
   }
   if (pos.node_->size() > 1)
   {
@@ -169,7 +169,7 @@ typename rychkov::MapBase< K, T, C, N, IsSet, IsMulti >::size_type
 {
   size_type result = 0;
   const_iterator iter = lower_bound(key);
-  for (; (iter != end()) && !compare_with_key(key, *iter); iter = erase(iter), result++)
+  for (; (iter != end()) && !compare_keys(key, get_key(*iter)); iter = erase(iter), result++)
   {}
   return result;
 }
@@ -181,7 +181,7 @@ typename rychkov::MapBase< K, T, C, N, IsSet, IsMulti >::transparent_compare_key
 {
   size_type result = 0;
   const_iterator iter = lower_bound(key);
-  for (; (iter != end()) && !compare_with_key(key, *iter); iter = erase(iter), result++)
+  for (; (iter != end()) && !compare_keys(key, get_key(*iter)); iter = erase(iter), result++)
   {}
   return result;
 }

--- a/rychkov.mihail/common/map_base/insert.hpp
+++ b/rychkov.mihail/common/map_base/insert.hpp
@@ -12,7 +12,7 @@ std::pair< typename rychkov::MapBase< K, T, C, N, IsSet, IsMulti >::const_iterat
     rychkov::MapBase< K, T, C, N, IsSet, IsMulti >::find_hint_pair(const K1& key) const
 {
   const_iterator hint = lower_bound_impl(key).first;
-  if (IsMulti || (hint.pointed_ >= hint.node_->size()) || compare_with_key(key, *hint))
+  if (IsMulti || (hint.pointed_ >= hint.node_->size()) || compare_keys(key, get_key(*hint)))
   {
     return {hint, true};
   }
@@ -29,13 +29,13 @@ std::pair< typename rychkov::MapBase< K, T, C, N, IsSet, IsMulti >::const_iterat
     return {end(), true};
   }
   bool correct = false;
-  const bool right_order = (hint != end()) && !compare_with_key(key, *hint);
+  const bool right_order = (hint != end()) && !compare_keys(key, (*hint));
   if (hint == end())
   {
     --hint;
-    if (!compare_with_key(key, *hint))
+    if (!compare_keys(key, get_key(*hint)))
     {
-      bool need_insert = IsMulti || !compare_with_key(*hint, key);
+      bool need_insert = IsMulti || !compare_keys(get_key(*hint), key);
       hint.pointed_++;
       return {hint, need_insert};
     }
@@ -46,7 +46,7 @@ std::pair< typename rychkov::MapBase< K, T, C, N, IsSet, IsMulti >::const_iterat
   }
   while (true)
   {
-    if (compare_with_key(key, *hint))
+    if (compare_keys(key, get_key(*hint)))
     {
       if (hint.node_->isleaf())
       {
@@ -56,7 +56,7 @@ std::pair< typename rychkov::MapBase< K, T, C, N, IsSet, IsMulti >::const_iterat
       hint.pointed_ = 0;
       correct = true;
     }
-    else if (!compare_with_key(*hint, key))
+    else if (!compare_keys(get_key(*hint), key))
     {
       if (!hint.node_->isleaf())
       {
@@ -101,7 +101,7 @@ std::pair< typename rychkov::MapBase< K, T, C, N, IsSet, IsMulti >::const_iterat
   bool correct = false;
   while (true)
   {
-    if (compare_with_key(*hint, key))
+    if (compare_keys(get_key(*hint), key))
     {
       if (hint.node_->isleaf())
       {
@@ -111,7 +111,7 @@ std::pair< typename rychkov::MapBase< K, T, C, N, IsSet, IsMulti >::const_iterat
       hint.pointed_ = hint.node_->size() - 1;
       correct = true;
     }
-    else if (!compare_with_key(key, *hint))
+    else if (!compare_keys(key, get_key(*hint)))
     {
       if (!hint.node_->isleaf())
       {

--- a/rychkov.mihail/common/map_base/search.hpp
+++ b/rychkov.mihail/common/map_base/search.hpp
@@ -6,30 +6,16 @@
 #include <iterator>
 
 template< class K, class T, class C, size_t N, bool IsSet, bool IsMulti >
-template< bool IsSet2 >
-bool rychkov::MapBase< K, T, C, N, IsSet, IsMulti >::compare_with_key
-    (std::enable_if_t< !IsSet && !IsSet2, const value_type >& lhs, const key_type& rhs) const
-{
-  return comp_.comp(lhs.first, rhs);
-}
-template< class K, class T, class C, size_t N, bool IsSet, bool IsMulti >
-template< bool IsSet2 >
-bool rychkov::MapBase< K, T, C, N, IsSet, IsMulti >::compare_with_key
-    (const key_type& lhs, std::enable_if_t< !IsSet && !IsSet2, const value_type >& rhs) const
-{
-  return comp_.comp(lhs, rhs.first);
-}
-template< class K, class T, class C, size_t N, bool IsSet, bool IsMulti >
-template< bool IsSet2 >
-std::enable_if_t< IsSet && IsSet2, bool > rychkov::MapBase< K, T, C, N, IsSet, IsMulti >::compare_with_key
-    (const key_type& lhs, const key_type& rhs) const
+template< bool IsSet2, class K1, class K2 >
+std::enable_if_t< IsSet && IsSet2, bool > rychkov::MapBase< K, T, C, N, IsSet, IsMulti >::compare_keys
+    (const K1& lhs, const K2& rhs) const
 {
   return comp_(lhs, rhs);
 }
 template< class K, class T, class C, size_t N, bool IsSet, bool IsMulti >
-template< bool IsSet2 >
-std::enable_if_t< !IsSet && !IsSet2, bool > rychkov::MapBase< K, T, C, N, IsSet, IsMulti >::compare_with_key
-    (const key_type& lhs, const key_type& rhs) const
+template< bool IsSet2, class K1, class K2 >
+std::enable_if_t< !IsSet && !IsSet2, bool > rychkov::MapBase< K, T, C, N, IsSet, IsMulti >::compare_keys
+    (const K1& lhs, const K2& rhs) const
 {
   return comp_.comp(lhs, rhs);
 }
@@ -60,7 +46,7 @@ std::pair< typename rychkov::MapBase< K, T, C, N, IsSet, IsMulti >::const_iterat
   const_iterator left = {fake_children_[0], 0}, right = end();
   while (true)
   {
-    if (compare_with_key(key, *left))
+    if (compare_keys(key, get_key(*left)))
     {
       right = left;
       if (left.node_->isleaf())
@@ -69,7 +55,7 @@ std::pair< typename rychkov::MapBase< K, T, C, N, IsSet, IsMulti >::const_iterat
       }
       left = {left.node_->children[left.pointed_], 0};
     }
-    else if (!compare_with_key(*left, key))
+    else if (!compare_keys(get_key(*left), key))
     {
       if (IsMulti)
       {
@@ -112,7 +98,7 @@ typename rychkov::MapBase< K, T, C, N, IsSet, IsMulti >::const_iterator
     node_size_type i = 0;
     while (i < left.node_->size())
     {
-      if (compare_with_key(key, left.node_->operator[](i)))
+      if (compare_keys(key, get_key(left.node_->operator[](i))))
       {
         right = {left.node_, i};
         if (left.node_->isleaf())
@@ -164,14 +150,14 @@ typename rychkov::MapBase< K, T, C, N, IsSet, IsMulti >::iterator
     rychkov::MapBase< K, T, C, N, IsSet, IsMulti >::find(const key_type& key)
 {
   const_iterator temp = lower_bound(key);
-  return ((temp != end()) && !compare_with_key(key, *temp)) ? iterator{temp.node_, temp.pointed_} : end();
+  return ((temp != end()) && !compare_keys(key, get_key(*temp))) ? iterator{temp.node_, temp.pointed_} : end();
 }
 template< class K, class T, class C, size_t N, bool IsSet, bool IsMulti >
 typename rychkov::MapBase< K, T, C, N, IsSet, IsMulti >::const_iterator
     rychkov::MapBase< K, T, C, N, IsSet, IsMulti >::find(const key_type& key) const
 {
   const_iterator temp = lower_bound(key);
-  return ((temp != end()) && !compare_with_key(key, *temp)) ? temp : end();
+  return ((temp != end()) && !compare_keys(key, get_key(*temp))) ? temp : end();
 }
 template< class K, class T, class C, size_t N, bool IsSet, bool IsMulti >
 bool rychkov::MapBase< K, T, C, N, IsSet, IsMulti >::contains(const key_type& key) const
@@ -240,7 +226,7 @@ typename rychkov::MapBase< K, T, C, N, IsSet, IsMulti >::transparent_compare_key
     rychkov::MapBase< K, T, C, N, IsSet, IsMulti >::find(const K1& key)
 {
   const_iterator temp = lower_bound(key);
-  return ((temp != end()) && !compare_with_key(key, *temp)) ? iterator{temp.node_, temp.pointed_} : end();
+  return ((temp != end()) && !compare_keys(key, get_key(*temp))) ? iterator{temp.node_, temp.pointed_} : end();
 }
 template< class K, class T, class C, size_t N, bool IsSet, bool IsMulti >
 template< class K1 >
@@ -249,7 +235,7 @@ typename rychkov::MapBase< K, T, C, N, IsSet, IsMulti >::transparent_compare_key
     rychkov::MapBase< K, T, C, N, IsSet, IsMulti >::find(const K1& key) const
 {
   const_iterator temp = lower_bound(key);
-  return ((temp != end()) && !compare_with_key(key, *temp)) ? temp : end();
+  return ((temp != end()) && !compare_keys(key, get_key(*temp))) ? temp : end();
 }
 template< class K, class T, class C, size_t N, bool IsSet, bool IsMulti >
 template< class K1 >

--- a/rychkov.mihail/common/parser.cpp
+++ b/rychkov.mihail/common/parser.cpp
@@ -5,7 +5,7 @@
 
 bool rychkov::eol(std::istream& in)
 {
-  for (char c = in.peek(); in.peek() != '\n'; in.get(), c = in.peek())
+  for (char c = in.peek(); in && (in.peek() != '\n'); in.get(), c = in.peek())
   {
     if (!std::isspace(c))
     {

--- a/rychkov.mihail/common/variant/base/copy_move_construct_base.hpp
+++ b/rychkov.mihail/common/variant/base/copy_move_construct_base.hpp
@@ -39,7 +39,8 @@ struct rychkov::details::CopyCtorBase< rychkov::details::USER_DEFINED, Types... 
   constexpr CopyCtorBase(in_place_index_t< N > i, Args&&... args):
     UnionStorageAlias< Types... >(i, std::forward< Args >(args)...)
   {}
-  constexpr CopyCtorBase(const CopyCtorBase& rhs) noexcept(is_nothrow_copy_ctor)
+  constexpr CopyCtorBase(const CopyCtorBase& rhs) noexcept(is_nothrow_copy_ctor):
+    UnionStorageAlias< Types... >(in_place_index_t< sizeof...(Types) >{})
   {
     if (!rhs.valueless_by_exception())
     {
@@ -83,7 +84,8 @@ struct rychkov::details::MoveCtorBase< rychkov::details::USER_DEFINED, Types... 
 
   MoveCtorBase() = default;
   constexpr MoveCtorBase(const MoveCtorBase& rhs) = default;
-  constexpr MoveCtorBase(MoveCtorBase&& rhs) noexcept(is_nothrow_move_ctor)
+  constexpr MoveCtorBase(MoveCtorBase&& rhs) noexcept(is_nothrow_move_ctor):
+    CopyCtorBaseAlias< Types... >(in_place_index_t< sizeof...(Types) >{})
   {
     if (!rhs.valueless_by_exception())
     {

--- a/rychkov.mihail/common/variant/base/union_base.hpp
+++ b/rychkov.mihail/common/variant/base/union_base.hpp
@@ -47,6 +47,8 @@ union rychkov::details::UnionBase< IsTrivDestr >
   UnionBase() = default;
   template< size_t N, class... Args >
   UnionBase(in_place_index_t< N >, Args&&... args) = delete;
+  constexpr UnionBase(in_place_index_t< 0 >)
+  {}
 };
 
 template< class... Types >
@@ -61,6 +63,10 @@ struct rychkov::details::UnionStorage< false, Types... >
   constexpr UnionStorage(in_place_index_t< N > i, Args&&... args):
     storage(i, std::forward< Args >(args)...),
     active(N)
+  {}
+  constexpr UnionStorage(in_place_index_t< sizeof...(Types) > i):
+    storage(i),
+    active(static_cast< size_type >(variant_npos))
   {}
   ~UnionStorage()
   {

--- a/rychkov.mihail/common/variant/class/access.hpp
+++ b/rychkov.mihail/common/variant/class/access.hpp
@@ -58,7 +58,7 @@ template< class T, class... Types >
 constexpr std::enable_if_t< rychkov::exactly_once< T, Types... >, const T& >
     rychkov::get(const Variant< Types... >& variant)
 {
-  return get< find_unique_v< T, Types... >() >(variant);
+  return get< find_unique_v< T, Types... > >(variant);
 }
 template< class T, class... Types >
 constexpr std::enable_if_t< rychkov::exactly_once< T, Types... >, T&& >

--- a/rychkov.mihail/common/variant/declaration.hpp
+++ b/rychkov.mihail/common/variant/declaration.hpp
@@ -10,11 +10,14 @@ namespace rychkov
   template< class... Types >
   class Variant;
 
+  struct Monostate
+  {};
+
   template< class T, class... Types >
-  constexpr std::enable_if_t< exactly_once< T >, T* >
+  constexpr std::enable_if_t< exactly_once< T, Types... >, T* >
       get_if(Variant< Types... >* variant) noexcept;
   template< class T, class... Types >
-  constexpr std::enable_if_t< exactly_once< T >, const T* >
+  constexpr std::enable_if_t< exactly_once< T, Types... >, const T* >
       get_if(const Variant< Types... >* variant) noexcept;
   template< size_t N, class... Types >
   nth_type_t< N, Types... >* get_if(Variant< Types... >* variant) noexcept;
@@ -60,7 +63,7 @@ namespace rychkov
     template< size_t N, class... Ts >
     friend nth_type_t< N, Ts... >* rychkov::get_if(Variant< Ts... >* variant) noexcept;
     template< size_t N, class... Ts >
-    friend const nth_type_t< N, Ts... >* rychkov::get_if(const Variant* variant) noexcept;
+    friend const nth_type_t< N, Ts... >* rychkov::get_if(const Variant< Ts... >* variant) noexcept;
   };
 
   template< class T, class... Types >


### PR DESCRIPTION
# Description:

Program implements code parsing (semantic analysis) on restricted and not significantly changed C99


# Command line arguments:

```xml
--help print manual info
-c <files...> parse code from files before start. If parsing fails in any of the files, print
  the corresponding errors and exit with a non-zero return code without completing processing
  of the remaining files
--load <file> load saved data (only fully parsed). If loading fails, print the corresponding
  errors but start interactive environment (if there is no -c flag)
-E stop on preprocessor parsing stage
-L stop on tokenizer parsing stage
-o print result in the corresponding files (.i after preprocessor, .lex after tokenizer,
  .json after full parsing). If it is specified, interactive environment will not be started
-I <path> add global include path
```

# Interactive environment commands:

```xml
* save [<save_file>] - save (rewrite) fully parsed data to file
* load [<save_file>] - load (reload) reload saved data (only fully parsed). Replaces existing data
  only on success
* parse <files...> - parse files. Replaces existing data only on full success
* parse-after [<parsed>] - parse input in non-interactive environment in file context. On success
  prints id, which will be equal to filename
* reload-all - reparse all existing files (with reloading). On success removes unreal files (from parse-after)

* external - print all external symbols
* exposition <parsed> <class_like_obj> - print struct/union/enum exposition
* defines <parsed> - print all macros that have ever appeared in file
* tree <parsed> [<function>] - print tree for file/function
* files - print all parsed filenames and ids

* dependencies <parsed> <symbol> - find and print all symbol's dependencies (symbol =
  function/global variable)
* uses <parsed> (<symbol> || <class_like_obj>) - find and print all places where
  symbol/struct/union/enum is used
* intersections - find and print exactly the same symbols/macros
* diff [<parsed...>] - find and print symbols/macros with same names, but with different types/different
  arglists or bodies
* unopen-defines <parsed> - print all preprocessed lines, which contain macro names, but it is not opened
  (before #define or after #undef or inside literals)
```

## Clarifications
* non-interactive environment = before "$EOF" or eof
* default save file - last saved place or "./save.json"
* if files repeat in the same pack it will be parsed only once